### PR TITLE
[SKG-70] Migrates the API from synchronous API Gateway → Lambda execution to an async “submit + poll” job pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ aws --profile sagebrain sso login
 | NeptuneStack | `app-dev-neptune` | Neptune cluster + S3 data bucket + load role |
 | NeptuneSageMakerStack | `app-dev-neptune-sagemaker` | SageMaker Studio for team data loading |
 | NeptuneApiStack | `app-dev-neptune-api` | API Gateway + Lambda read-only SPARQL API |
-| NeptuneAgentStack | `app-dev-neptune-agent` | Bedrock Strands AI agent — NL-to-SPARQL via `POST /ask` |
+| NeptuneAgentStack | `app-dev-neptune-agent` | Bedrock Strands AI agent — async NL-to-SPARQL via `POST /ask` + `GET /ask/{job_id}` |
 
 ## S3 Data Bucket
 
@@ -72,71 +72,109 @@ cdk deploy app-dev-neptune-agent --profile sagebrain --require-approval never
 
 Use `--hotswap` only for Lambda code changes. API Gateway method/stage/IAM changes need a full deploy — hotswap will silently skip them.
 
-## Lambda: src/lambda/query.py
+## Query API: src/lambda/ (async job pattern)
 
-Handles SPARQL queries against Neptune via `POST /query` with a JSON body `{"query": "<SPARQL>"}`.
+Three Lambdas + SQS + DynamoDB — mirrors the agent's async pattern.
 
-- Accepts POST only (no GET) — avoids URL length limits for complex queries
-- Query length capped at 8000 characters (DoS/cost guard)
+### submit.py — POST /query
+- Validates query (max 8000 chars), writes `status=pending` to DynamoDB, enqueues to SQS
+- Returns `202 {"job_id": "...", "status": "pending"}` immediately
+- Captures caller metadata (IP, user agent, X-Source) and passes it in the SQS message for audit logging
+
+### status.py — GET /query/{job_id}
+- Reads job from DynamoDB
+- `complete` → `results` (raw SPARQL JSON string) + `content_type`; `error` → `error` message
+
+### query.py — SQS worker
+- SQS-triggered (batch size 1), runs in VPC to reach Neptune
 - Signs requests with SigV4 (`neptune-db` service)
-- Forwards Neptune's `Content-Type` header (typically `application/sparql-results+json`)
-- CORS headers (`Access-Control-Allow-Origin: *`) on all responses including errors
+- **60s Neptune timeout** — handles 40s+ complex queries on the 2.27M-triple graph
 - Only has `ReadDataViaQuery`, `GetEngineStatus`, `GetQueryStatus` IAM permissions
-- **Logs every query** to CloudWatch as structured JSON including `source` (`"direct"` or `"agent"`), IP, user agent, duration, and status code
+- **Logs every query** to CloudWatch as structured JSON: `job_id`, `source`, IP, user agent, duration, status
 
-Get the live endpoint from CloudFormation:
+Get endpoints from CloudFormation:
 ```bash
 aws --profile sagebrain cloudformation describe-stacks \
   --stack-name app-dev-neptune-api \
-  --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" \
-  --output text
+  --query "Stacks[0].Outputs" --output table
 ```
 
 Test with curl:
 ```bash
-curl -X POST <ApiUrl> \
+# Submit
+JOB=$(curl -s -X POST <ApiUrl> \
   -H "Content-Type: application/json" \
-  -d '{"query": "SELECT * WHERE { ?s ?p ?o } LIMIT 5"}'
+  -d '{"query": "SELECT * WHERE { ?s ?p ?o } LIMIT 5"}')
+JOB_ID=$(echo $JOB | python3 -c "import sys,json; print(json.load(sys.stdin)['job_id'])")
+
+# Poll
+curl <ApiUrl>/$JOB_ID
 ```
 
-## Lambda: src/lambda_agent/agent.py
+## Agent API: src/lambda_agent/ (async job pattern)
 
-Handles natural-language questions via `POST /ask` with a JSON body `{"question": "<question>"}`.
+Three Lambdas + SQS + DynamoDB implement a fire-and-poll pattern that eliminates the 29s API Gateway timeout.
 
-- Uses [Strands Agents SDK](https://strandsagents.com) with a `query_neptune` tool
+### Flow
+```
+POST /ask  →  submit.py  →  SQS  →  agent.py (worker)  →  DynamoDB
+GET /ask/{job_id}  →  status.py  →  DynamoDB
+```
+
+### submit.py — POST /ask
+- Generates a UUID `job_id`, writes `status=pending` to DynamoDB, enqueues to SQS
+- Returns `202 {"job_id": "...", "status": "pending"}` immediately (no Bedrock/Neptune calls)
+
+### status.py — GET /ask/{job_id}
+- Reads job from DynamoDB and returns current state
+- `pending` / `running` → poll again; `complete` → `answer` + `steps`; `error` → `error` + `steps`
+
+### agent.py — SQS worker
+- SQS-triggered (batch size 1). Uses [Strands Agents SDK](https://strandsagents.com) with a `query_neptune` tool
 - Model: `us.anthropic.claude-sonnet-4-6` (cross-region inference profile)
-- Calls `POST /query` internally — does NOT sign directly to Neptune. This keeps all query traffic through the single audit-logged chokepoint.
-- Returns `{"answer": "...", "steps": [...]}` — `steps` contains each tool call and result for UI transparency
-- **Logs every invocation** to CloudWatch: question, status, step count, duration
+- Calls `POST /query` internally — keeps all query traffic through the single audit-logged chokepoint
+- Writes `status=complete` (with `answer`/`steps`) or `status=error` to DynamoDB when done
+- **Logs every invocation** to CloudWatch: `job_id`, question, status, step count, duration
+- Concurrency capped at 10 — prevents Bedrock/Neptune overload under burst traffic
+- Failed jobs retry twice then land in the DLQ
 - Requires **Bedrock model access** enabled in AWS Console → Bedrock → Model access (one-time account setup)
 
-Get the live endpoint from CloudFormation:
+### DynamoDB job items
+- TTL: 24 hours after creation
+- `status`: `pending` → `running` → `complete` | `error`
+
+Get endpoints from CloudFormation:
 ```bash
 aws --profile sagebrain cloudformation describe-stacks \
   --stack-name app-dev-neptune-agent \
-  --query "Stacks[0].Outputs[?OutputKey=='AgentApiUrl'].OutputValue" \
-  --output text
+  --query "Stacks[0].Outputs" --output table
 ```
 
 Test with curl:
 ```bash
-curl -X POST <AgentApiUrl> \
+# Submit
+JOB=$(curl -s -X POST <AgentApiUrl> \
   -H "Content-Type: application/json" \
-  -d '{"question": "What types of biological entities are in this knowledge graph?"}'
+  -d '{"question": "What types of biological entities are in this knowledge graph?"}')
+JOB_ID=$(echo $JOB | python3 -c "import sys,json; print(json.load(sys.stdin)['job_id'])")
+
+# Poll
+curl <AgentApiUrl>/$JOB_ID
 ```
 
 ## API Gateway
 
-### app-dev-neptune-api (`POST /query`)
-- **Throttling**: 50 RPS steady-state, 100 burst
+### app-dev-neptune-api (`POST /query`, `GET /query/{job_id}`)
+- **Throttling**: 50 RPS steady-state, 100 burst (lightweight — no Neptune calls inline)
+- **Timeout**: 10s integration timeout (submit/status are fast; SPARQL runs async in worker)
 - **Access logs**: CloudWatch log group with 1-month retention (every request, structured JSON)
 - **Execution logs**: ERROR level only
 - **CloudWatch role**: set via `cloud_watch_role=True` on `RestApi`
 - No authentication — intentionally public read-only; throttling + IAM read-only scope are the mitigations
 
-### app-dev-neptune-agent (`POST /ask`)
-- **Throttling**: 10 RPS steady-state, 20 burst (agent calls are slower and more expensive)
-- **Timeout**: 29s hard limit (API Gateway constraint) — typical agent responses complete in 10-20s
+### app-dev-neptune-agent (`POST /ask`, `GET /ask/{job_id}`)
+- **Throttling**: 50 RPS steady-state, 100 burst (lightweight — no Bedrock/Neptune calls inline)
+- **Timeout**: 10s integration timeout (submit/status are fast; agent runs async in worker)
 - **Access logs**: CloudWatch log group with 1-month retention
 - No authentication — same public posture as `/query`
 
@@ -188,5 +226,7 @@ Tests live in `tests/unit/`. Lambda handler tests import from `src/lambda/` via 
 - **S3 bulk loader** is used for all data loading — not SPARQL INSERT batches. Neptune assumes `NeptuneLoadRole` (trusted by `rds.amazonaws.com`) to read from S3.
 - **Date-partitioned S3 layout** (`YYYY-MM-DD/schema/` and `YYYY-MM-DD/data/rdf/`) preserves a historical data lake. Each load is a full reset + reload from a chosen prefix.
 - **SageMaker Studio** runs in `VpcOnly` mode so notebook kernels can reach Neptune. Requires VPC interface endpoints for `sagemaker.api` and `sts` (in NetworkStack).
-- **Agent routes through `/query`** rather than calling Neptune directly. This keeps `/query` as the single access control chokepoint — when node/edge-level filtering or caller-based ACLs are added, the agent inherits them for free.
+- **Both APIs are async (submit + poll)** — Neptune SPARQL on the 2.27M-triple graph takes 4–40s; synchronous API Gateway has a hard 29s limit. SQS + DynamoDB decouples HTTP from execution for both `/query` and `/ask`.
+- **Agent routes through `/query`** rather than calling Neptune directly. The `query_neptune` tool submits to `/query` and polls `/query/{job_id}` — keeps all query traffic through the single audit-logged chokepoint, and the agent inherits future ACLs for free.
+- **Worker concurrency is capped** — query worker uncapped (SPARQL is read-only); agent worker capped at 10 concurrent invocations to prevent Bedrock rate-limit errors under burst traffic.
 - **Agent Lambda is ARM_64** — bundled with `platform=linux/arm64` to match compiled dependencies on Apple Silicon dev machines.

--- a/app.py
+++ b/app.py
@@ -62,12 +62,13 @@ neptune_api_stack = NeptuneApiStack(
 )
 # Note: No explicit dependency needed as the direct references create implicit dependencies
 
-# Bedrock Strands AI agent: POST /ask with NL-to-SPARQL
+# Bedrock Strands AI agent: async POST /ask + GET /ask/{job_id}
 neptune_agent_stack = NeptuneAgentStack(
     scope=cdk_app,
     construct_id=f"{STACK_NAME_PREFIX}-neptune-agent",
     vpc=network_stack.vpc,
     neptune_query_url=f"{neptune_api_stack.api.url}query",
+    neptune_query_status_url=f"{neptune_api_stack.api.url}query",
     env=env,
 )
 

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from src.network_stack import NetworkStack
 from src.neptune_api_stack import NeptuneApiStack
 from src.neptune_sagemaker_stack import NeptuneSageMakerStack
 from src.neptune_stack import NeptuneStack
+from src.monitoring_stack import MonitoringStack
 from src.utils import load_context_config
 
 cdk_app = cdk.App()
@@ -69,6 +70,27 @@ neptune_agent_stack = NeptuneAgentStack(
     vpc=network_stack.vpc,
     neptune_query_url=f"{neptune_api_stack.api.url}query",
     neptune_query_status_url=f"{neptune_api_stack.api.url}query",
+    env=env,
+)
+
+monitoring_stack = MonitoringStack(
+    scope=cdk_app,
+    construct_id=f"{STACK_NAME_PREFIX}-monitoring",
+    query_api=neptune_api_stack.api,
+    query_submit_fn=neptune_api_stack.submit_fn,
+    query_status_fn=neptune_api_stack.status_fn,
+    query_worker_fn=neptune_api_stack.query_fn,
+    query_job_queue=neptune_api_stack.job_queue,
+    query_dlq=neptune_api_stack.dlq,
+    query_job_table=neptune_api_stack.job_table,
+    agent_api=neptune_agent_stack.api,
+    agent_submit_fn=neptune_agent_stack.submit_fn,
+    agent_status_fn=neptune_agent_stack.status_fn,
+    agent_worker_fn=neptune_agent_stack.agent_fn,
+    agent_job_queue=neptune_agent_stack.job_queue,
+    agent_dlq=neptune_agent_stack.dlq,
+    agent_job_table=neptune_agent_stack.job_table,
+    neptune_cluster_id=neptune_stack.neptune_cluster.ref,
     env=env,
 )
 

--- a/docs/neptune.md
+++ b/docs/neptune.md
@@ -7,8 +7,8 @@ Amazon Neptune cluster for the Sage Brain knowledge graph.
 - **Neptune Cluster**: Managed graph database in private subnets, IAM auth enabled
 - **Security Groups**: No broad ingress — each consumer stack adds a targeted SG-to-SG rule on port 8182
 - **SageMaker Studio**: Team access for loading and querying data via JupyterLab (VpcOnly mode, routes through VPC)
-- **Public SPARQL API** (`app-dev-neptune-api`): Read-only `POST /query` endpoint via API Gateway + Lambda. All queries logged to CloudWatch with source, IP, duration, and query text.
-- **AI Agent API** (`app-dev-neptune-agent`): Natural-language `POST /ask` endpoint. Bedrock Strands (Claude Sonnet 4.6) translates questions to SPARQL, calls `/query` internally, and returns a plain-language answer with the full reasoning trace.
+- **Public SPARQL API** (`app-dev-neptune-api`): Async read-only SPARQL interface. `POST /query` submits a job and returns a `job_id`. A worker Lambda executes the SPARQL against Neptune and writes results to DynamoDB. Callers poll `GET /query/{job_id}`. All queries logged to CloudWatch with source, IP, duration, and query text.
+- **AI Agent API** (`app-dev-neptune-agent`): Async natural-language interface. `POST /ask` enqueues a job and returns a `job_id` immediately. A worker Lambda (Bedrock Strands / Claude Sonnet 4.6) processes the job via SQS, writes the result to DynamoDB, and the caller polls `GET /ask/{job_id}` for the answer.
 - **Backup & Monitoring**: Automated backups and CloudWatch audit/slow-query logging
 
 ## Accessing Neptune
@@ -81,11 +81,37 @@ pd.DataFrame(rows)
 
 ### From the Public SPARQL API (read-only, no auth)
 
-A read-only SPARQL endpoint is available over HTTPS. See the [README](../README.md) for the URL and usage.
+SPARQL queries use the same async job pattern as `/ask`:
+
+```bash
+# 1. Submit query — returns immediately with a job_id
+curl -X POST <ApiUrl> \
+  -H "Content-Type: application/json" \
+  -d '{"query": "SELECT (COUNT(*) AS ?c) WHERE { ?s ?p ?o }"}'
+# → {"job_id": "abc-123", "status": "pending"}
+
+# 2. Poll until status is "complete" or "error"
+curl <ApiUrl>/abc-123
+# → {"job_id": "abc-123", "status": "complete", "results": "{...sparql-results+json...}", "content_type": "..."}
+```
+
+Complex queries on the 2.27M-triple graph can take 25–40s — the async pattern means they complete successfully rather than hitting a 504.
 
 ### From the AI Agent API (natural language)
 
-Ask questions in plain English at `POST /ask`. See the [README](../README.md) for the URL and usage.
+Ask questions in plain English using the async job pattern:
+
+```bash
+# 1. Submit a question — returns immediately with a job_id
+curl -X POST <AgentApiUrl> \
+  -H "Content-Type: application/json" \
+  -d '{"question": "What genes are linked to NF1?"}'
+# → {"job_id": "abc-123", "status": "pending"}
+
+# 2. Poll until status is "complete" or "error"
+curl <AgentApiUrl>/abc-123
+# → {"job_id": "abc-123", "status": "complete", "answer": "...", "steps": [...]}
+```
 
 The agent routes all SPARQL through `/query`, so every agent-generated query appears in the query audit log with `"source": "agent"`.
 
@@ -271,6 +297,8 @@ CloudWatch logs enabled for:
 | `ConnectTimeout` from Studio | Space wasn't restarted after SG/network change — stop and restart the space |
 | `AccessDeniedException` on Neptune | Request not SigV4-signed, or IAM role missing Neptune permissions |
 | `TimeoutError` on port 8182 | Security group rule missing, or VPC routing issue |
-| `Endpoint request timed out` from `/ask` | Agent ran >29s (multi-hop query) — API Gateway hard limit. Simplify the question or migrate to WebSocket (Phase 2) |
+| `POST /ask` returns 504 | Should not happen — submit Lambda only enqueues. Check if the stack was redeployed with the new async stack. |
+| `GET /ask/{job_id}` returns `{"status": "pending"}` indefinitely | Worker Lambda may have errored — check the worker log group (`NeptuneAgentWorkerFunction`). Failed jobs land in the DLQ after 2 retries. |
+| `GET /ask/{job_id}` returns `{"status": "error"}` | Agent error (Bedrock timeout, bad SPARQL, etc.) — `"error"` field has the message; `"steps"` shows how far it got. |
 | `AccessDeniedException` on Bedrock | Claude Sonnet 4.6 model access not enabled — go to **AWS Console → Bedrock → Model access** and request access |
 | Agent answers but no query logs | Agent is calling `/query` correctly — check the query Lambda log group, not the agent log group |

--- a/src/lambda/query.py
+++ b/src/lambda/query.py
@@ -92,6 +92,9 @@ def _execute_query(
         )
         duration = (time.time() - start) * 1000
         _log_query(job_id, query, source, source_ip, user_agent, 200, duration)
+        # TODO: response.text is stored raw in DynamoDB; large result sets can exceed
+        # the 400KB item size limit, causing this update to fail even though Neptune
+        # succeeded. Consider truncating at ~300KB or offloading results to S3.
         _update_job(
             job_id,
             status="complete",

--- a/src/lambda/query.py
+++ b/src/lambda/query.py
@@ -1,8 +1,10 @@
 import json
 import os
 import time
+from decimal import Decimal
 from urllib.parse import urlencode
 
+import boto3
 import botocore.session
 import requests
 from botocore.auth import SigV4Auth
@@ -10,28 +12,47 @@ from botocore.awsrequest import AWSRequest
 
 NEPTUNE_ENDPOINT = os.environ["NEPTUNE_ENDPOINT"]
 REGION = os.environ["AWS_REGION"]
+DYNAMODB_TABLE = os.environ["JOB_TABLE_NAME"]
 
-CORS_HEADERS = {
-    "Access-Control-Allow-Origin": "*",
-}
-
-MAX_QUERY_LENGTH = 8000
+_dynamodb = boto3.resource("dynamodb")
 
 
-def _log_query(query: str, event: dict, status_code: int, duration_ms: float):
-    headers = event.get("headers") or {}
-    source_ip = (
-        event.get("requestContext", {}).get("identity", {}).get("sourceIp", "unknown")
+def _update_job(job_id: str, **fields):
+    table = _dynamodb.Table(DYNAMODB_TABLE)
+    update_expr = "SET " + ", ".join(f"#{k} = :{k}" for k in fields)
+    expr_names = {f"#{k}": k for k in fields}
+    # DynamoDB doesn't support float — convert to Decimal
+    expr_values = {
+        f":{k}": Decimal(str(v)) if isinstance(v, float) else v
+        for k, v in fields.items()
+    }
+    table.update_item(
+        Key={"job_id": job_id},
+        UpdateExpression=update_expr,
+        ExpressionAttributeNames=expr_names,
+        ExpressionAttributeValues=expr_values,
     )
+
+
+def _log_query(
+    job_id: str,
+    query: str,
+    source: str,
+    source_ip: str,
+    user_agent: str,
+    status_code: int,
+    duration_ms: float,
+):
     print(
         json.dumps(
             {
                 "event": "sparql_query",
+                "job_id": job_id,
                 "query": query,
                 "query_length": len(query),
-                "source": headers.get("X-Source", "direct"),
+                "source": source,
                 "source_ip": source_ip,
-                "user_agent": headers.get("User-Agent", "unknown"),
+                "user_agent": user_agent,
                 "status_code": status_code,
                 "duration_ms": round(duration_ms, 2),
                 "timestamp": time.time(),
@@ -40,29 +61,11 @@ def _log_query(query: str, event: dict, status_code: int, duration_ms: float):
     )
 
 
-def handler(event, context):
+def _execute_query(
+    job_id: str, query: str, source: str, source_ip: str, user_agent: str
+):
     start = time.time()
-
-    try:
-        body = json.loads(event.get("body") or "{}")
-        query = body.get("query", "SELECT * WHERE { ?s ?p ?o } LIMIT 10")
-    except json.JSONDecodeError:
-        return {
-            "statusCode": 400,
-            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
-            "body": json.dumps({"error": "Request body must be valid JSON"}),
-        }
-
-    if len(query) > MAX_QUERY_LENGTH:
-        return {
-            "statusCode": 400,
-            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
-            "body": json.dumps(
-                {
-                    "error": f"Query exceeds maximum length of {MAX_QUERY_LENGTH} characters"
-                }
-            ),
-        }
+    _update_job(job_id, status="running")
 
     url = f"https://{NEPTUNE_ENDPOINT}:8182/sparql"
     body = urlencode({"query": query})
@@ -81,29 +84,43 @@ def handler(event, context):
             url,
             data=body,
             headers=dict(aws_request.headers),
-            timeout=30,
+            timeout=60,  # Neptune can be slow on complex queries
         )
         response.raise_for_status()
         content_type = response.headers.get(
             "Content-Type", "application/sparql-results+json"
         )
-        _log_query(query, event, 200, (time.time() - start) * 1000)
-        return {
-            "statusCode": 200,
-            "headers": {"Content-Type": content_type, **CORS_HEADERS},
-            "body": response.text,
-        }
+        duration = (time.time() - start) * 1000
+        _log_query(job_id, query, source, source_ip, user_agent, 200, duration)
+        _update_job(
+            job_id,
+            status="complete",
+            results=response.text,
+            content_type=content_type,
+            duration_ms=round(duration, 2),
+        )
     except requests.exceptions.HTTPError as e:
-        _log_query(query, event, response.status_code, (time.time() - start) * 1000)
-        return {
-            "statusCode": response.status_code,
-            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
-            "body": json.dumps({"error": str(e)}),
-        }
+        duration = (time.time() - start) * 1000
+        _log_query(
+            job_id, query, source, source_ip, user_agent, response.status_code, duration
+        )
+        _update_job(job_id, status="error", error=str(e))
+        raise
     except Exception as e:
-        _log_query(query, event, 500, (time.time() - start) * 1000)
-        return {
-            "statusCode": 500,
-            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
-            "body": json.dumps({"error": str(e)}),
-        }
+        duration = (time.time() - start) * 1000
+        _log_query(job_id, query, source, source_ip, user_agent, 500, duration)
+        _update_job(job_id, status="error", error=str(e))
+        raise
+
+
+def handler(event, context):
+    """SQS-triggered worker. Each record is one SPARQL query job."""
+    for record in event["Records"]:
+        body = json.loads(record["body"])
+        _execute_query(
+            job_id=body["job_id"],
+            query=body["query"],
+            source=body.get("source", "direct"),
+            source_ip=body.get("source_ip", "unknown"),
+            user_agent=body.get("user_agent", "unknown"),
+        )

--- a/src/lambda/status.py
+++ b/src/lambda/status.py
@@ -1,0 +1,50 @@
+import json
+import os
+
+import boto3
+
+DYNAMODB_TABLE = os.environ["JOB_TABLE_NAME"]
+
+_dynamodb = boto3.resource("dynamodb")
+
+CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+}
+
+
+def handler(event, context):
+    job_id = (event.get("pathParameters") or {}).get("job_id", "").strip()
+
+    if not job_id:
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+            "body": json.dumps({"error": "Missing job_id"}),
+        }
+
+    response = _dynamodb.Table(DYNAMODB_TABLE).get_item(Key={"job_id": job_id})
+    item = response.get("Item")
+
+    if not item:
+        return {
+            "statusCode": 404,
+            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+            "body": json.dumps({"error": "Job not found"}),
+        }
+
+    status = item["status"]
+    result = {"job_id": job_id, "status": status}
+
+    if status == "complete":
+        result["results"] = item.get("results", {})
+        result["content_type"] = item.get(
+            "content_type", "application/sparql-results+json"
+        )
+    elif status == "error":
+        result["error"] = item.get("error", "Unknown error")
+
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+        "body": json.dumps(result),
+    }

--- a/src/lambda/status.py
+++ b/src/lambda/status.py
@@ -36,7 +36,7 @@ def handler(event, context):
     result = {"job_id": job_id, "status": status}
 
     if status == "complete":
-        result["results"] = item.get("results", {})
+        result["results"] = item.get("results", "")
         result["content_type"] = item.get(
             "content_type", "application/sparql-results+json"
         )

--- a/src/lambda/submit.py
+++ b/src/lambda/submit.py
@@ -1,0 +1,86 @@
+import json
+import os
+import time
+import uuid
+
+import boto3
+
+DYNAMODB_TABLE = os.environ["JOB_TABLE_NAME"]
+SQS_QUEUE_URL = os.environ["JOB_QUEUE_URL"]
+
+_dynamodb = boto3.resource("dynamodb")
+_sqs = boto3.client("sqs")
+
+CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+}
+
+MAX_QUERY_LENGTH = 8000
+JOB_TTL_SECONDS = 86400  # 24 hours
+
+
+def handler(event, context):
+    try:
+        body = json.loads(event.get("body") or "{}")
+        query = body.get("query", "").strip()
+    except json.JSONDecodeError:
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+            "body": json.dumps({"error": "Request body must be valid JSON"}),
+        }
+
+    if not query:
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+            "body": json.dumps({"error": "Missing 'query' field"}),
+        }
+
+    if len(query) > MAX_QUERY_LENGTH:
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+            "body": json.dumps(
+                {
+                    "error": f"Query exceeds maximum length of {MAX_QUERY_LENGTH} characters"
+                }
+            ),
+        }
+
+    # Capture caller metadata for audit logging by the worker
+    headers = event.get("headers") or {}
+    source_ip = (
+        event.get("requestContext", {}).get("identity", {}).get("sourceIp", "unknown")
+    )
+
+    job_id = str(uuid.uuid4())
+    now = time.time()
+
+    _dynamodb.Table(DYNAMODB_TABLE).put_item(
+        Item={
+            "job_id": job_id,
+            "status": "pending",
+            "created_at": int(now),
+            "ttl": int(now) + JOB_TTL_SECONDS,
+        }
+    )
+
+    _sqs.send_message(
+        QueueUrl=SQS_QUEUE_URL,
+        MessageBody=json.dumps(
+            {
+                "job_id": job_id,
+                "query": query,
+                "source": headers.get("X-Source", "direct"),
+                "source_ip": source_ip,
+                "user_agent": headers.get("User-Agent", "unknown"),
+            }
+        ),
+    )
+
+    return {
+        "statusCode": 202,
+        "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+        "body": json.dumps({"job_id": job_id, "status": "pending"}),
+    }

--- a/src/lambda_agent/agent.py
+++ b/src/lambda_agent/agent.py
@@ -1,5 +1,6 @@
 import json
 import os
+import random
 import time
 from decimal import Decimal
 
@@ -54,6 +55,11 @@ def query_neptune(sparql: str) -> str:
     Use standard SPARQL 1.1 syntax with PREFIX declarations."""
     _steps.append({"type": "tool_call", "tool": "query_neptune", "sparql": sparql})
     _flush_steps()
+    if _current_job_id:
+        _update_job(
+            _current_job_id,
+            status_detail=f"Executing SPARQL query (step {len(_steps)})...",
+        )
 
     # Submit job
     submit_response = requests.post(
@@ -97,9 +103,14 @@ def query_neptune(sparql: str) -> str:
             _flush_steps()
             raise RuntimeError(f"SPARQL query failed: {error_msg}")
 
-    raise TimeoutError(
+    timeout_msg = (
         f"SPARQL query job {job_id} did not complete within {QUERY_POLL_TIMEOUT}s"
     )
+    _steps.append(
+        {"type": "tool_result", "tool": "query_neptune", "error": timeout_msg}
+    )
+    _flush_steps()
+    raise TimeoutError(timeout_msg)
 
 
 def _update_job(job_id: str, **fields):
@@ -132,23 +143,33 @@ def _invoke_agent_with_retry(agent, question: str, job_id: str):
         global _steps
         _steps = []
         _flush_steps()
+        _update_job(
+            job_id,
+            status_detail=f"Generating SPARQL query (attempt {attempt + 1}/{MAX_ATTEMPTS})...",
+        )
         try:
             return agent(question)
         except Exception as e:
             is_transient = "ServiceUnavailableException" in str(e)
             if is_transient and attempt < MAX_ATTEMPTS - 1:
+                _update_job(
+                    job_id,
+                    status_detail=f"Model temporarily unavailable, retrying ({attempt + 2}/{MAX_ATTEMPTS})...",
+                )
+                jitter = random.uniform(0, 10)
+                wait = RETRY_WAIT + jitter
                 print(
                     json.dumps(
                         {
                             "event": "bedrock_retry",
                             "job_id": job_id,
                             "attempt": attempt + 1,
-                            "wait_s": RETRY_WAIT,
+                            "wait_s": round(wait, 1),
                             "error": str(e)[:200],
                         }
                     )
                 )
-                time.sleep(RETRY_WAIT)
+                time.sleep(wait)
             else:
                 raise
 

--- a/src/lambda_agent/agent.py
+++ b/src/lambda_agent/agent.py
@@ -1,18 +1,25 @@
 import json
 import os
 import time
+from decimal import Decimal
 
+import boto3
 import requests
 from strands import Agent, tool
 from strands.models.bedrock import BedrockModel
 
 NEPTUNE_QUERY_URL = os.environ["NEPTUNE_QUERY_URL"]
+# Base URL for polling: GET {NEPTUNE_QUERY_STATUS_URL}/{job_id}
+# Derived from NEPTUNE_QUERY_URL if not explicitly set (same API, different path)
+NEPTUNE_QUERY_STATUS_URL = os.environ.get("NEPTUNE_QUERY_STATUS_URL", NEPTUNE_QUERY_URL)
 BEDROCK_MODEL_ID = os.environ.get("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-6")
 REGION = os.environ.get("AWS_REGION", "us-east-1")
+DYNAMODB_TABLE = os.environ["JOB_TABLE_NAME"]
 
-CORS_HEADERS = {
-    "Access-Control-Allow-Origin": "*",
-}
+QUERY_POLL_INTERVAL = 3  # seconds between polls
+QUERY_POLL_TIMEOUT = 80  # seconds before giving up (within 90s Lambda timeout)
+
+_dynamodb = boto3.resource("dynamodb")
 
 SYSTEM_PROMPT = """You are a biomedical knowledge graph assistant for the Sage Brain project.
 You have access to a Neptune RDF graph containing biomedical data about genes, diseases,
@@ -38,70 +45,74 @@ def query_neptune(sparql: str) -> str:
     Use standard SPARQL 1.1 syntax with PREFIX declarations."""
     _steps.append({"type": "tool_call", "tool": "query_neptune", "sparql": sparql})
 
-    response = requests.post(
+    # Submit job
+    submit_response = requests.post(
         NEPTUNE_QUERY_URL,
         json={"query": sparql},
         headers={"X-Source": "agent"},
-        timeout=25,
+        timeout=10,
     )
-    response.raise_for_status()
+    submit_response.raise_for_status()
+    job_id = submit_response.json()["job_id"]
 
-    result_text = response.text
-    _steps.append(
-        {
-            "type": "tool_result",
-            "tool": "query_neptune",
-            "preview": result_text[:500],
-        }
-    )
-    return result_text
-
-
-def _log_invocation(
-    question: str, event: dict, status: str, duration_ms: float, step_count: int
-):
-    source_ip = (
-        event.get("requestContext", {}).get("identity", {}).get("sourceIp", "unknown")
-    )
-    user_agent = (event.get("headers") or {}).get("User-Agent", "unknown")
-    print(
-        json.dumps(
-            {
-                "event": "agent_invocation",
-                "question": question,
-                "question_length": len(question),
-                "status": status,
-                "step_count": step_count,
-                "duration_ms": round(duration_ms, 2),
-                "source_ip": source_ip,
-                "user_agent": user_agent,
-                "timestamp": time.time(),
-            }
+    # Poll until complete or timeout
+    deadline = time.time() + QUERY_POLL_TIMEOUT
+    while time.time() < deadline:
+        time.sleep(QUERY_POLL_INTERVAL)
+        poll = requests.get(
+            f"{NEPTUNE_QUERY_STATUS_URL}/{job_id}",
+            timeout=10,
         )
+        poll.raise_for_status()
+        data = poll.json()
+        status = data["status"]
+
+        if status == "complete":
+            result_text = data.get("results", "")
+            _steps.append(
+                {
+                    "type": "tool_result",
+                    "tool": "query_neptune",
+                    "preview": result_text[:500],
+                }
+            )
+            return result_text
+
+        if status == "error":
+            error_msg = data.get("error", "Unknown query error")
+            _steps.append(
+                {"type": "tool_result", "tool": "query_neptune", "error": error_msg}
+            )
+            raise RuntimeError(f"SPARQL query failed: {error_msg}")
+
+    raise TimeoutError(
+        f"SPARQL query job {job_id} did not complete within {QUERY_POLL_TIMEOUT}s"
     )
 
 
-def handler(event, context):
+def _update_job(job_id: str, **fields):
+    table = _dynamodb.Table(DYNAMODB_TABLE)
+    update_expr = "SET " + ", ".join(f"#{k} = :{k}" for k in fields)
+    expr_names = {f"#{k}": k for k in fields}
+    # DynamoDB doesn't support float — convert to Decimal
+    expr_values = {
+        f":{k}": Decimal(str(v)) if isinstance(v, float) else v
+        for k, v in fields.items()
+    }
+    table.update_item(
+        Key={"job_id": job_id},
+        UpdateExpression=update_expr,
+        ExpressionAttributeNames=expr_names,
+        ExpressionAttributeValues=expr_values,
+    )
+
+
+def _process_job(job_id: str, question: str):
     global _steps
     _steps = []
     start = time.time()
 
-    try:
-        body = json.loads(event.get("body") or "{}")
-        question = body.get("question", "").strip()
-    except json.JSONDecodeError:
-        return {
-            "statusCode": 400,
-            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
-            "body": json.dumps({"error": "Request body must be valid JSON"}),
-        }
-
-    if not question:
-        return {
-            "statusCode": 400,
-            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
-            "body": json.dumps({"error": "Missing 'question' field"}),
-        }
+    _update_job(job_id, status="running")
 
     model = BedrockModel(model_id=BEDROCK_MODEL_ID, region_name=REGION)
     agent = Agent(
@@ -113,22 +124,50 @@ def handler(event, context):
     try:
         result = agent(question)
         duration = (time.time() - start) * 1000
-        _log_invocation(question, event, "success", duration, len(_steps))
-        return {
-            "statusCode": 200,
-            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
-            "body": json.dumps(
+        _update_job(
+            job_id,
+            status="complete",
+            answer=str(result),
+            steps=_steps,
+            duration_ms=round(duration, 2),
+        )
+        print(
+            json.dumps(
                 {
-                    "answer": str(result),
-                    "steps": _steps,
+                    "event": "agent_invocation",
+                    "job_id": job_id,
+                    "question": question,
+                    "status": "success",
+                    "step_count": len(_steps),
+                    "duration_ms": round(duration, 2),
+                    "timestamp": time.time(),
                 }
-            ),
-        }
+            )
+        )
     except Exception as e:
         duration = (time.time() - start) * 1000
-        _log_invocation(question, event, "error", duration, len(_steps))
-        return {
-            "statusCode": 500,
-            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
-            "body": json.dumps({"error": str(e), "steps": _steps}),
-        }
+        _update_job(job_id, status="error", error=str(e), steps=_steps)
+        print(
+            json.dumps(
+                {
+                    "event": "agent_invocation",
+                    "job_id": job_id,
+                    "question": question,
+                    "status": "error",
+                    "error": str(e),
+                    "step_count": len(_steps),
+                    "duration_ms": round(duration, 2),
+                    "timestamp": time.time(),
+                }
+            )
+        )
+        raise  # re-raise so SQS can retry via DLQ
+
+
+def handler(event, context):
+    """SQS-triggered worker. Each record is one job."""
+    for record in event["Records"]:
+        body = json.loads(record["body"])
+        job_id = body["job_id"]
+        question = body["question"]
+        _process_job(job_id, question)

--- a/src/lambda_agent/agent.py
+++ b/src/lambda_agent/agent.py
@@ -44,6 +44,8 @@ _current_job_id: str = ""
 
 def _flush_steps():
     """Write current steps to DynamoDB so the polling client sees live progress."""
+    # TODO: steps grow with each tool call; a long-running agent can accumulate enough
+    # steps to push the item over DynamoDB's 400KB limit before the job even completes.
     if _current_job_id:
         _update_job(_current_job_id, steps=_steps)
 
@@ -192,6 +194,9 @@ def _process_job(job_id: str, question: str):
     try:
         result = _invoke_agent_with_retry(agent, question, job_id)
         duration = (time.time() - start) * 1000
+        # TODO: answer + steps are stored in a single DynamoDB item; a verbose agent
+        # response with many steps can exceed the 400KB item size limit.
+        # Consider truncating steps or offloading large payloads to S3.
         _update_job(
             job_id,
             status="complete",
@@ -214,6 +219,7 @@ def _process_job(job_id: str, question: str):
         )
     except Exception as e:
         duration = (time.time() - start) * 1000
+        # TODO: steps written on error path can also exceed 400KB if the agent ran many iterations.
         _update_job(job_id, status="error", error=str(e), steps=_steps)
         print(
             json.dumps(

--- a/src/lambda_agent/agent.py
+++ b/src/lambda_agent/agent.py
@@ -17,7 +17,9 @@ REGION = os.environ.get("AWS_REGION", "us-east-1")
 DYNAMODB_TABLE = os.environ["JOB_TABLE_NAME"]
 
 QUERY_POLL_INTERVAL = 3  # seconds between polls
-QUERY_POLL_TIMEOUT = 80  # seconds before giving up (within 90s Lambda timeout)
+QUERY_POLL_TIMEOUT = (
+    70  # seconds before giving up; Neptune query worker has 75s timeout
+)
 
 _dynamodb = boto3.resource("dynamodb")
 

--- a/src/lambda_agent/agent.py
+++ b/src/lambda_agent/agent.py
@@ -36,8 +36,15 @@ When a user asks a question:
 Always explain what you found and how confident you are in the answer.
 """
 
-# Module-level list reset per invocation to capture tool calls for the response.
+# Module-level state reset per invocation.
 _steps: list = []
+_current_job_id: str = ""
+
+
+def _flush_steps():
+    """Write current steps to DynamoDB so the polling client sees live progress."""
+    if _current_job_id:
+        _update_job(_current_job_id, steps=_steps)
 
 
 @tool
@@ -46,6 +53,7 @@ def query_neptune(sparql: str) -> str:
     Returns results as a JSON string with 'results.bindings' containing the rows.
     Use standard SPARQL 1.1 syntax with PREFIX declarations."""
     _steps.append({"type": "tool_call", "tool": "query_neptune", "sparql": sparql})
+    _flush_steps()
 
     # Submit job
     submit_response = requests.post(
@@ -78,6 +86,7 @@ def query_neptune(sparql: str) -> str:
                     "preview": result_text[:500],
                 }
             )
+            _flush_steps()
             return result_text
 
         if status == "error":
@@ -85,6 +94,7 @@ def query_neptune(sparql: str) -> str:
             _steps.append(
                 {"type": "tool_result", "tool": "query_neptune", "error": error_msg}
             )
+            _flush_steps()
             raise RuntimeError(f"SPARQL query failed: {error_msg}")
 
     raise TimeoutError(
@@ -109,9 +119,44 @@ def _update_job(job_id: str, **fields):
     )
 
 
+def _invoke_agent_with_retry(agent, question: str, job_id: str):
+    """
+    Call the Strands agent, retrying on transient Bedrock capacity errors.
+    Wait 30s between attempts; 2 retries fit within the 300s Lambda budget.
+    """
+    MAX_ATTEMPTS = 3
+    RETRY_WAIT = 30
+
+    for attempt in range(MAX_ATTEMPTS):
+        # Reset steps so a retry shows a clean trace
+        global _steps
+        _steps = []
+        _flush_steps()
+        try:
+            return agent(question)
+        except Exception as e:
+            is_transient = "ServiceUnavailableException" in str(e)
+            if is_transient and attempt < MAX_ATTEMPTS - 1:
+                print(
+                    json.dumps(
+                        {
+                            "event": "bedrock_retry",
+                            "job_id": job_id,
+                            "attempt": attempt + 1,
+                            "wait_s": RETRY_WAIT,
+                            "error": str(e)[:200],
+                        }
+                    )
+                )
+                time.sleep(RETRY_WAIT)
+            else:
+                raise
+
+
 def _process_job(job_id: str, question: str):
-    global _steps
+    global _steps, _current_job_id
     _steps = []
+    _current_job_id = job_id
     start = time.time()
 
     _update_job(job_id, status="running")
@@ -124,7 +169,7 @@ def _process_job(job_id: str, question: str):
     )
 
     try:
-        result = agent(question)
+        result = _invoke_agent_with_retry(agent, question, job_id)
         duration = (time.time() - start) * 1000
         _update_job(
             job_id,

--- a/src/lambda_agent/status.py
+++ b/src/lambda_agent/status.py
@@ -35,12 +35,17 @@ def handler(event, context):
     status = item["status"]
     result = {"job_id": job_id, "status": status}
 
+    if "status_detail" in item:
+        result["status_detail"] = item["status_detail"]
+
+    # Always return steps so callers can see in-progress SPARQL queries
+    if item.get("steps"):
+        result["steps"] = item["steps"]
+
     if status == "complete":
         result["answer"] = item.get("answer", "")
-        result["steps"] = item.get("steps", [])
     elif status == "error":
         result["error"] = item.get("error", "Unknown error")
-        result["steps"] = item.get("steps", [])
 
     return {
         "statusCode": 200,

--- a/src/lambda_agent/status.py
+++ b/src/lambda_agent/status.py
@@ -1,0 +1,49 @@
+import json
+import os
+
+import boto3
+
+DYNAMODB_TABLE = os.environ["JOB_TABLE_NAME"]
+
+_dynamodb = boto3.resource("dynamodb")
+
+CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+}
+
+
+def handler(event, context):
+    job_id = (event.get("pathParameters") or {}).get("job_id", "").strip()
+
+    if not job_id:
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+            "body": json.dumps({"error": "Missing job_id"}),
+        }
+
+    response = _dynamodb.Table(DYNAMODB_TABLE).get_item(Key={"job_id": job_id})
+    item = response.get("Item")
+
+    if not item:
+        return {
+            "statusCode": 404,
+            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+            "body": json.dumps({"error": "Job not found"}),
+        }
+
+    status = item["status"]
+    result = {"job_id": job_id, "status": status}
+
+    if status == "complete":
+        result["answer"] = item.get("answer", "")
+        result["steps"] = item.get("steps", [])
+    elif status == "error":
+        result["error"] = item.get("error", "Unknown error")
+        result["steps"] = item.get("steps", [])
+
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+        "body": json.dumps(result),
+    }

--- a/src/lambda_agent/submit.py
+++ b/src/lambda_agent/submit.py
@@ -1,0 +1,61 @@
+import json
+import os
+import time
+import uuid
+
+import boto3
+
+DYNAMODB_TABLE = os.environ["JOB_TABLE_NAME"]
+SQS_QUEUE_URL = os.environ["JOB_QUEUE_URL"]
+
+_dynamodb = boto3.resource("dynamodb")
+_sqs = boto3.client("sqs")
+
+CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+}
+
+JOB_TTL_SECONDS = 86400  # 24 hours
+
+
+def handler(event, context):
+    try:
+        body = json.loads(event.get("body") or "{}")
+        question = body.get("question", "").strip()
+    except json.JSONDecodeError:
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+            "body": json.dumps({"error": "Request body must be valid JSON"}),
+        }
+
+    if not question:
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+            "body": json.dumps({"error": "Missing 'question' field"}),
+        }
+
+    job_id = str(uuid.uuid4())
+    now = time.time()
+
+    _dynamodb.Table(DYNAMODB_TABLE).put_item(
+        Item={
+            "job_id": job_id,
+            "status": "pending",
+            "question": question,
+            "created_at": int(now),
+            "ttl": int(now) + JOB_TTL_SECONDS,
+        }
+    )
+
+    _sqs.send_message(
+        QueueUrl=SQS_QUEUE_URL,
+        MessageBody=json.dumps({"job_id": job_id, "question": question}),
+    )
+
+    return {
+        "statusCode": 202,
+        "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+        "body": json.dumps({"job_id": job_id, "status": "pending"}),
+    }

--- a/src/lambda_agent/submit.py
+++ b/src/lambda_agent/submit.py
@@ -15,6 +15,7 @@ CORS_HEADERS = {
     "Access-Control-Allow-Origin": "*",
 }
 
+MAX_QUESTION_LENGTH = 2000
 JOB_TTL_SECONDS = 86400  # 24 hours
 
 
@@ -34,6 +35,17 @@ def handler(event, context):
             "statusCode": 400,
             "headers": {"Content-Type": "application/json", **CORS_HEADERS},
             "body": json.dumps({"error": "Missing 'question' field"}),
+        }
+
+    if len(question) > MAX_QUESTION_LENGTH:
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json", **CORS_HEADERS},
+            "body": json.dumps(
+                {
+                    "error": f"Question exceeds maximum length of {MAX_QUESTION_LENGTH} characters"
+                }
+            ),
         }
 
     job_id = str(uuid.uuid4())

--- a/src/monitoring_stack.py
+++ b/src/monitoring_stack.py
@@ -182,7 +182,7 @@ class MonitoringStack(cdk.Stack):
             threshold=1,
             evaluation_periods=1,
             comparison_operator=cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-            alarm_description="Query jobs landing in DLQ — all 3 attempts failed",
+            alarm_description="Query jobs landing in DLQ — all 2 attempts failed",
             treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
         )
         dashboard.add_widgets(
@@ -344,7 +344,7 @@ class MonitoringStack(cdk.Stack):
             threshold=1,
             evaluation_periods=1,
             comparison_operator=cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-            alarm_description="Agent jobs landing in DLQ — all 3 attempts failed",
+            alarm_description="Agent jobs landing in DLQ — all 2 attempts failed",
             treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
         )
         dashboard.add_widgets(

--- a/src/monitoring_stack.py
+++ b/src/monitoring_stack.py
@@ -1,0 +1,490 @@
+import aws_cdk as cdk
+from aws_cdk import aws_cloudwatch as cw
+from aws_cdk import aws_apigateway as apigw
+from aws_cdk import aws_dynamodb as dynamodb
+from aws_cdk import aws_lambda as lambda_
+from aws_cdk import aws_sqs as sqs
+from constructs import Construct
+
+
+class MonitoringStack(cdk.Stack):
+    """
+    CloudWatch dashboard covering both APIs, all Lambdas, SQS queues/DLQs,
+    DynamoDB tables, and Neptune.
+
+    Layout (top to bottom):
+      - Query API  (API GW, Lambdas, SQS + DLQ alarm, DynamoDB)
+      - Agent API  (API GW, Lambdas + concurrency, SQS + DLQ alarm, DynamoDB)
+      - Neptune    (CPU, memory, SPARQL req/s, cache hit ratio)
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        # Query API resources
+        query_api: apigw.RestApi,
+        query_submit_fn: lambda_.Function,
+        query_status_fn: lambda_.Function,
+        query_worker_fn: lambda_.Function,
+        query_job_queue: sqs.Queue,
+        query_dlq: sqs.Queue,
+        query_job_table: dynamodb.Table,
+        # Agent API resources
+        agent_api: apigw.RestApi,
+        agent_submit_fn: lambda_.Function,
+        agent_status_fn: lambda_.Function,
+        agent_worker_fn: lambda_.Function,
+        agent_job_queue: sqs.Queue,
+        agent_dlq: sqs.Queue,
+        agent_job_table: dynamodb.Table,
+        # Neptune
+        neptune_cluster_id: str,
+        **kwargs,
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        def _apigw_metric(api: apigw.RestApi, metric_name: str, **kwargs) -> cw.Metric:
+            return cw.Metric(
+                namespace="AWS/ApiGateway",
+                metric_name=metric_name,
+                dimensions_map={"ApiName": api.rest_api_name},
+                **kwargs,
+            )
+
+        def _neptune_metric(metric_name: str, **kwargs) -> cw.Metric:
+            return cw.Metric(
+                namespace="AWS/Neptune",
+                metric_name=metric_name,
+                dimensions_map={"DBClusterIdentifier": neptune_cluster_id},
+                **kwargs,
+            )
+
+        dashboard = cw.Dashboard(
+            self,
+            "SageBrainDashboard",
+            dashboard_name=f"{construct_id}-overview",
+            default_interval=cdk.Duration.hours(3),
+        )
+
+        # ------------------------------------------------------------------ #
+        # Query API
+        # ------------------------------------------------------------------ #
+        dashboard.add_widgets(
+            cw.TextWidget(
+                markdown="# Query API  (`POST /query` · `GET /query/{job_id}`)",
+                width=24,
+                height=1,
+            )
+        )
+        dashboard.add_widgets(
+            cw.GraphWidget(
+                title="Requests & Errors",
+                left=[
+                    _apigw_metric(
+                        query_api,
+                        "Count",
+                        statistic="Sum",
+                        label="Requests",
+                        period=cdk.Duration.minutes(1),
+                    )
+                ],
+                right=[
+                    _apigw_metric(
+                        query_api,
+                        "4XXError",
+                        statistic="Sum",
+                        label="4XX",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                    _apigw_metric(
+                        query_api,
+                        "5XXError",
+                        statistic="Sum",
+                        label="5XX",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                ],
+                width=12,
+            ),
+            cw.GraphWidget(
+                title="Latency (ms)",
+                left=[
+                    _apigw_metric(
+                        query_api,
+                        "Latency",
+                        statistic="p50",
+                        label="p50",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                    _apigw_metric(
+                        query_api,
+                        "Latency",
+                        statistic="p99",
+                        label="p99",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                ],
+                width=12,
+            ),
+        )
+        dashboard.add_widgets(
+            cw.GraphWidget(
+                title="Lambda Errors",
+                left=[
+                    query_submit_fn.metric_errors(
+                        label="submit", period=cdk.Duration.minutes(1)
+                    ),
+                    query_status_fn.metric_errors(
+                        label="status", period=cdk.Duration.minutes(1)
+                    ),
+                    query_worker_fn.metric_errors(
+                        label="worker", period=cdk.Duration.minutes(1)
+                    ),
+                ],
+                width=8,
+            ),
+            cw.GraphWidget(
+                title="Worker Duration (ms)",
+                left=[
+                    query_worker_fn.metric_duration(
+                        statistic="p50", label="p50", period=cdk.Duration.minutes(1)
+                    ),
+                    query_worker_fn.metric_duration(
+                        statistic="p99", label="p99", period=cdk.Duration.minutes(1)
+                    ),
+                    query_worker_fn.metric_duration(
+                        statistic="Maximum", label="max", period=cdk.Duration.minutes(1)
+                    ),
+                ],
+                width=8,
+            ),
+            cw.GraphWidget(
+                title="SQS Queue Depth",
+                left=[
+                    query_job_queue.metric_approximate_number_of_messages_visible(
+                        label="visible", period=cdk.Duration.minutes(1)
+                    ),
+                    query_job_queue.metric_approximate_number_of_messages_not_visible(
+                        label="in-flight", period=cdk.Duration.minutes(1)
+                    ),
+                ],
+                width=8,
+            ),
+        )
+
+        query_dlq_alarm = cw.Alarm(
+            self,
+            "QueryDLQAlarm",
+            metric=query_dlq.metric_approximate_number_of_messages_visible(
+                period=cdk.Duration.minutes(1)
+            ),
+            threshold=1,
+            evaluation_periods=1,
+            comparison_operator=cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            alarm_description="Query jobs landing in DLQ — all 3 attempts failed",
+            treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
+        )
+        dashboard.add_widgets(
+            cw.AlarmWidget(
+                title="Query DLQ (alarm if > 0 messages)",
+                alarm=query_dlq_alarm,
+                width=8,
+            ),
+            cw.GraphWidget(
+                title="DynamoDB — Query Jobs Latency (ms)",
+                left=[
+                    query_job_table.metric_successful_request_latency(
+                        dimensions_map={
+                            "TableName": query_job_table.table_name,
+                            "Operation": "PutItem",
+                        },
+                        label="PutItem",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                    query_job_table.metric_successful_request_latency(
+                        dimensions_map={
+                            "TableName": query_job_table.table_name,
+                            "Operation": "GetItem",
+                        },
+                        label="GetItem",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                    query_job_table.metric_successful_request_latency(
+                        dimensions_map={
+                            "TableName": query_job_table.table_name,
+                            "Operation": "UpdateItem",
+                        },
+                        label="UpdateItem",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                ],
+                width=16,
+            ),
+        )
+
+        # ------------------------------------------------------------------ #
+        # Agent API
+        # ------------------------------------------------------------------ #
+        dashboard.add_widgets(
+            cw.TextWidget(
+                markdown="# Agent API  (`POST /ask` · `GET /ask/{job_id}`)",
+                width=24,
+                height=1,
+            )
+        )
+        dashboard.add_widgets(
+            cw.GraphWidget(
+                title="Requests & Errors",
+                left=[
+                    _apigw_metric(
+                        agent_api,
+                        "Count",
+                        statistic="Sum",
+                        label="Requests",
+                        period=cdk.Duration.minutes(1),
+                    )
+                ],
+                right=[
+                    _apigw_metric(
+                        agent_api,
+                        "4XXError",
+                        statistic="Sum",
+                        label="4XX",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                    _apigw_metric(
+                        agent_api,
+                        "5XXError",
+                        statistic="Sum",
+                        label="5XX",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                ],
+                width=12,
+            ),
+            cw.GraphWidget(
+                title="Latency (ms)",
+                left=[
+                    _apigw_metric(
+                        agent_api,
+                        "Latency",
+                        statistic="p50",
+                        label="p50",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                    _apigw_metric(
+                        agent_api,
+                        "Latency",
+                        statistic="p99",
+                        label="p99",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                ],
+                width=12,
+            ),
+        )
+        dashboard.add_widgets(
+            cw.GraphWidget(
+                title="Lambda Errors & Throttles",
+                left=[
+                    agent_submit_fn.metric_errors(
+                        label="submit errors", period=cdk.Duration.minutes(1)
+                    ),
+                    agent_status_fn.metric_errors(
+                        label="status errors", period=cdk.Duration.minutes(1)
+                    ),
+                    agent_worker_fn.metric_errors(
+                        label="worker errors", period=cdk.Duration.minutes(1)
+                    ),
+                    agent_worker_fn.metric_throttles(
+                        label="worker throttles", period=cdk.Duration.minutes(1)
+                    ),
+                ],
+                width=8,
+            ),
+            cw.GraphWidget(
+                title="Worker Duration (ms)",
+                left=[
+                    agent_worker_fn.metric_duration(
+                        statistic="p50", label="p50", period=cdk.Duration.minutes(1)
+                    ),
+                    agent_worker_fn.metric_duration(
+                        statistic="p99", label="p99", period=cdk.Duration.minutes(1)
+                    ),
+                    agent_worker_fn.metric_duration(
+                        statistic="Maximum", label="max", period=cdk.Duration.minutes(1)
+                    ),
+                ],
+                width=8,
+            ),
+            # Concurrency is critical — agent worker is capped at 10
+            cw.GraphWidget(
+                title="Worker Concurrency (max=10)",
+                left=[
+                    cw.Metric(
+                        namespace="AWS/Lambda",
+                        metric_name="ConcurrentExecutions",
+                        dimensions_map={"FunctionName": agent_worker_fn.function_name},
+                        statistic="Maximum",
+                        label="concurrent",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                ],
+                width=8,
+            ),
+        )
+
+        agent_dlq_alarm = cw.Alarm(
+            self,
+            "AgentDLQAlarm",
+            metric=agent_dlq.metric_approximate_number_of_messages_visible(
+                period=cdk.Duration.minutes(1)
+            ),
+            threshold=1,
+            evaluation_periods=1,
+            comparison_operator=cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            alarm_description="Agent jobs landing in DLQ — all 3 attempts failed",
+            treat_missing_data=cw.TreatMissingData.NOT_BREACHING,
+        )
+        dashboard.add_widgets(
+            cw.AlarmWidget(
+                title="Agent DLQ (alarm if > 0 messages)",
+                alarm=agent_dlq_alarm,
+                width=8,
+            ),
+            cw.GraphWidget(
+                title="SQS Queue Depth",
+                left=[
+                    agent_job_queue.metric_approximate_number_of_messages_visible(
+                        label="visible", period=cdk.Duration.minutes(1)
+                    ),
+                    agent_job_queue.metric_approximate_number_of_messages_not_visible(
+                        label="in-flight", period=cdk.Duration.minutes(1)
+                    ),
+                ],
+                width=8,
+            ),
+            cw.GraphWidget(
+                title="DynamoDB — Agent Jobs Latency (ms)",
+                left=[
+                    agent_job_table.metric_successful_request_latency(
+                        dimensions_map={
+                            "TableName": agent_job_table.table_name,
+                            "Operation": "PutItem",
+                        },
+                        label="PutItem",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                    agent_job_table.metric_successful_request_latency(
+                        dimensions_map={
+                            "TableName": agent_job_table.table_name,
+                            "Operation": "GetItem",
+                        },
+                        label="GetItem",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                    agent_job_table.metric_successful_request_latency(
+                        dimensions_map={
+                            "TableName": agent_job_table.table_name,
+                            "Operation": "UpdateItem",
+                        },
+                        label="UpdateItem",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                ],
+                width=8,
+            ),
+        )
+
+        # ------------------------------------------------------------------ #
+        # Neptune
+        # ------------------------------------------------------------------ #
+        dashboard.add_widgets(
+            cw.TextWidget(
+                markdown="# Neptune",
+                width=24,
+                height=1,
+            )
+        )
+        dashboard.add_widgets(
+            cw.GraphWidget(
+                title="CPU Utilization (%)",
+                left=[
+                    _neptune_metric(
+                        "CPUUtilization",
+                        statistic="Average",
+                        label="CPU",
+                        period=cdk.Duration.minutes(1),
+                    )
+                ],
+                width=8,
+            ),
+            cw.GraphWidget(
+                title="Freeable Memory (bytes)",
+                left=[
+                    _neptune_metric(
+                        "FreeableMemory",
+                        statistic="Average",
+                        label="Free Memory",
+                        period=cdk.Duration.minutes(1),
+                    )
+                ],
+                width=8,
+            ),
+            cw.GraphWidget(
+                title="Buffer Cache Hit Ratio (%)",
+                left=[
+                    _neptune_metric(
+                        "BufferCacheHitRatio",
+                        statistic="Average",
+                        label="Cache Hit %",
+                        period=cdk.Duration.minutes(1),
+                    )
+                ],
+                width=8,
+            ),
+        )
+        dashboard.add_widgets(
+            cw.GraphWidget(
+                title="SPARQL Requests / sec",
+                left=[
+                    _neptune_metric(
+                        "SparqlRequestsPerSec",
+                        statistic="Average",
+                        label="req/s",
+                        period=cdk.Duration.minutes(1),
+                    )
+                ],
+                width=12,
+            ),
+            cw.GraphWidget(
+                title="Network Throughput (bytes/s)",
+                left=[
+                    _neptune_metric(
+                        "NetworkReceiveThroughput",
+                        statistic="Average",
+                        label="in",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                    _neptune_metric(
+                        "NetworkTransmitThroughput",
+                        statistic="Average",
+                        label="out",
+                        period=cdk.Duration.minutes(1),
+                    ),
+                ],
+                width=12,
+            ),
+        )
+
+        # -------------------------------------------------------------- #
+        # Outputs
+        # -------------------------------------------------------------- #
+        result = f"https://{self.region}.console.aws.amazon.com/cloudwatch/home#dashboards:name={construct_id}-overview"
+        cdk.CfnOutput(
+            self,
+            "DashboardUrl",
+            value=result,
+            description="CloudWatch dashboard URL",
+        )

--- a/src/neptune_agent_stack.py
+++ b/src/neptune_agent_stack.py
@@ -1,22 +1,37 @@
 import aws_cdk as cdk
 from aws_cdk import aws_apigateway as apigw
+from aws_cdk import aws_dynamodb as dynamodb
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as lambda_
+from aws_cdk import aws_lambda_event_sources as lambda_event_sources
 from aws_cdk import aws_logs as logs
+from aws_cdk import aws_sqs as sqs
 from constructs import Construct
+
+
+def _bundling(runtime):
+    return cdk.BundlingOptions(
+        image=runtime.bundling_image,
+        platform="linux/arm64",
+        command=[
+            "bash",
+            "-c",
+            "pip install -r requirements.txt -t /asset-output && cp -r . /asset-output",
+        ],
+    )
 
 
 class NeptuneAgentStack(cdk.Stack):
     """
-    Bedrock Strands AI agent: POST /ask takes a natural-language question,
-    generates and runs SPARQL against Neptune, returns a plain-language answer
-    plus the tool call steps for transparency.
+    Bedrock Strands AI agent: async POST /ask + GET /ask/{job_id} poll pattern.
 
-    Phase 1: synchronous API Gateway + Lambda.
-    Note: API Gateway has a hard 29s integration timeout. Typical agent loops
-    (1-2 tool calls) complete in 10-20s. Migrate to WebSocket API (Phase 2)
-    when real-time streaming of thinking loops is needed.
+    Flow:
+      POST /ask  →  submit Lambda  →  SQS  →  worker Lambda (agent)  →  DynamoDB
+      GET /ask/{job_id}  →  status Lambda  →  DynamoDB
+
+    This decouples HTTP from execution, absorbs traffic spikes, and eliminates
+    the API Gateway 29s hard limit that blocked synchronous agent responses.
     """
 
     def __init__(
@@ -25,61 +40,141 @@ class NeptuneAgentStack(cdk.Stack):
         construct_id: str,
         vpc: ec2.Vpc,
         neptune_query_url: str,
+        neptune_query_status_url: str,
         bedrock_model_id: str = "us.anthropic.claude-sonnet-4-6",
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         # -------------------
-        # Lambda Security Group
+        # DynamoDB — job store
+        # -------------------
+        self.job_table = dynamodb.Table(
+            self,
+            "AgentJobTable",
+            table_name=f"{construct_id}-jobs",
+            partition_key=dynamodb.Attribute(
+                name="job_id", type=dynamodb.AttributeType.STRING
+            ),
+            billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
+            time_to_live_attribute="ttl",
+            removal_policy=cdk.RemovalPolicy.DESTROY,
+        )
+
+        # -------------------
+        # SQS — job queue + DLQ
+        # -------------------
+        dlq = sqs.Queue(
+            self,
+            "AgentJobDLQ",
+            retention_period=cdk.Duration.days(14),
+        )
+        self.job_queue = sqs.Queue(
+            self,
+            "AgentJobQueue",
+            visibility_timeout=cdk.Duration.seconds(120),  # > worker Lambda timeout
+            dead_letter_queue=sqs.DeadLetterQueue(max_receive_count=2, queue=dlq),
+        )
+
+        # -------------------
+        # Security group (shared by all agent Lambdas needing VPC egress)
         # -------------------
         self.agent_sg = ec2.SecurityGroup(
             self,
             "NeptuneAgentFunctionSG",
             vpc=vpc,
-            description="Security group for Neptune agent Lambda",
+            description="Security group for Neptune agent Lambdas",
             allow_all_outbound=True,
         )
 
-        # -------------------
-        # Lambda Function
-        # -------------------
-        self.agent_fn = lambda_.Function(
-            self,
-            "NeptuneAgentFunction",
-            runtime=lambda_.Runtime.PYTHON_3_11,
-            handler="agent.handler",
-            code=lambda_.Code.from_asset(
-                "src/lambda_agent",
-                bundling=cdk.BundlingOptions(
-                    image=lambda_.Runtime.PYTHON_3_11.bundling_image,
-                    platform="linux/arm64",
-                    command=[
-                        "bash",
-                        "-c",
-                        "pip install -r requirements.txt -t /asset-output && cp -r . /asset-output",
-                    ],
-                ),
-            ),
-            architecture=lambda_.Architecture.ARM_64,
+        vpc_kwargs = dict(
             vpc=vpc,
             security_groups=[self.agent_sg],
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS
             ),
-            environment={
-                "NEPTUNE_QUERY_URL": neptune_query_url,
-                "BEDROCK_MODEL_ID": bedrock_model_id,
-            },
-            # 60s to allow headroom beyond the API Gateway 29s limit
-            # (useful if this Lambda is later invoked directly or via Function URL)
-            timeout=cdk.Duration.seconds(60),
-            memory_size=512,
         )
 
         # -------------------
-        # IAM: Bedrock model invocation
+        # Submit Lambda — POST /ask
         # -------------------
+        self.submit_fn = lambda_.Function(
+            self,
+            "NeptuneAgentSubmitFunction",
+            runtime=lambda_.Runtime.PYTHON_3_11,
+            handler="submit.handler",
+            code=lambda_.Code.from_asset(
+                "src/lambda_agent",
+                bundling=_bundling(lambda_.Runtime.PYTHON_3_11),
+            ),
+            architecture=lambda_.Architecture.ARM_64,
+            environment={
+                "JOB_TABLE_NAME": self.job_table.table_name,
+                "JOB_QUEUE_URL": self.job_queue.queue_url,
+            },
+            timeout=cdk.Duration.seconds(10),
+            memory_size=256,
+            # submit Lambda doesn't need VPC (no Neptune/Bedrock calls)
+        )
+        self.job_table.grant_write_data(self.submit_fn)
+        self.job_queue.grant_send_messages(self.submit_fn)
+
+        # -------------------
+        # Status Lambda — GET /ask/{job_id}
+        # -------------------
+        self.status_fn = lambda_.Function(
+            self,
+            "NeptuneAgentStatusFunction",
+            runtime=lambda_.Runtime.PYTHON_3_11,
+            handler="status.handler",
+            code=lambda_.Code.from_asset(
+                "src/lambda_agent",
+                bundling=_bundling(lambda_.Runtime.PYTHON_3_11),
+            ),
+            architecture=lambda_.Architecture.ARM_64,
+            environment={
+                "JOB_TABLE_NAME": self.job_table.table_name,
+            },
+            timeout=cdk.Duration.seconds(10),
+            memory_size=256,
+            # status Lambda doesn't need VPC either
+        )
+        self.job_table.grant_read_data(self.status_fn)
+
+        # -------------------
+        # Worker Lambda — SQS-triggered agent
+        # -------------------
+        self.agent_fn = lambda_.Function(
+            self,
+            "NeptuneAgentWorkerFunction",
+            runtime=lambda_.Runtime.PYTHON_3_11,
+            handler="agent.handler",
+            code=lambda_.Code.from_asset(
+                "src/lambda_agent",
+                bundling=_bundling(lambda_.Runtime.PYTHON_3_11),
+            ),
+            architecture=lambda_.Architecture.ARM_64,
+            **vpc_kwargs,
+            environment={
+                "NEPTUNE_QUERY_URL": neptune_query_url,
+                "NEPTUNE_QUERY_STATUS_URL": neptune_query_status_url,
+                "BEDROCK_MODEL_ID": bedrock_model_id,
+                "JOB_TABLE_NAME": self.job_table.table_name,
+            },
+            timeout=cdk.Duration.seconds(90),  # agent loops can be slow
+            memory_size=512,
+            # Cap concurrency to avoid overwhelming Bedrock/Neptune under burst traffic
+            reserved_concurrent_executions=10,
+        )
+        self.job_table.grant_read_write_data(self.agent_fn)
+        self.agent_fn.add_event_source(
+            lambda_event_sources.SqsEventSource(
+                self.job_queue,
+                batch_size=1,  # one job per invocation
+            )
+        )
+
+        # IAM: Bedrock model invocation (worker only)
         self.agent_fn.add_to_role_policy(
             iam.PolicyStatement(
                 effect=iam.Effect.ALLOW,
@@ -88,9 +183,7 @@ class NeptuneAgentStack(cdk.Stack):
                     "bedrock:InvokeModelWithResponseStream",
                 ],
                 resources=[
-                    # Foundation models (any region — cross-region profiles route to multiple US regions)
                     "arn:aws:bedrock:*::foundation-model/anthropic.claude-*",
-                    # Cross-region inference profiles
                     f"arn:aws:bedrock:{self.region}:{self.account}:inference-profile/us.anthropic.claude-*",
                 ],
             )
@@ -109,11 +202,11 @@ class NeptuneAgentStack(cdk.Stack):
             self,
             "NeptuneAgentApi",
             rest_api_name="neptune-agent-api",
-            description="NL-to-SPARQL agent API for Neptune knowledge graph",
+            description="Async NL-to-SPARQL agent API for Neptune knowledge graph",
             cloud_watch_role=True,
             default_cors_preflight_options=apigw.CorsOptions(
                 allow_origins=apigw.Cors.ALL_ORIGINS,
-                allow_methods=["POST", "OPTIONS"],
+                allow_methods=["POST", "GET", "OPTIONS"],
             ),
             deploy_options=apigw.StageOptions(
                 access_log_destination=apigw.LogGroupLogDestination(access_log_group),
@@ -130,18 +223,21 @@ class NeptuneAgentStack(cdk.Stack):
                 ),
                 logging_level=apigw.MethodLoggingLevel.ERROR,
                 metrics_enabled=True,
-                throttling_rate_limit=10,
-                throttling_burst_limit=20,
+                throttling_rate_limit=50,
+                throttling_burst_limit=100,
             ),
         )
 
         ask_resource = self.api.root.add_resource("ask")
         ask_resource.add_method(
             "POST",
-            apigw.LambdaIntegration(
-                self.agent_fn,
-                timeout=cdk.Duration.seconds(29),  # API Gateway hard limit
-            ),
+            apigw.LambdaIntegration(self.submit_fn, timeout=cdk.Duration.seconds(10)),
+        )
+
+        ask_job_resource = ask_resource.add_resource("{job_id}")
+        ask_job_resource.add_method(
+            "GET",
+            apigw.LambdaIntegration(self.status_fn, timeout=cdk.Duration.seconds(10)),
         )
 
         # -------------------
@@ -151,5 +247,17 @@ class NeptuneAgentStack(cdk.Stack):
             self,
             "AgentApiUrl",
             value=f"{self.api.url}ask",
-            description='Neptune NL agent API endpoint — POST {"question": "..."}',
+            description='Submit endpoint — POST {"question": "..."}  →  {"job_id": "...", "status": "pending"}',
+        )
+        cdk.CfnOutput(
+            self,
+            "AgentJobStatusUrl",
+            value=f"{self.api.url}ask/{{job_id}}",
+            description="Poll endpoint — GET /ask/{job_id}",
+        )
+        cdk.CfnOutput(
+            self,
+            "AgentJobTableName",
+            value=self.job_table.table_name,
+            description="DynamoDB table storing agent job results",
         )

--- a/src/neptune_agent_stack.py
+++ b/src/neptune_agent_stack.py
@@ -64,7 +64,7 @@ class NeptuneAgentStack(cdk.Stack):
         # -------------------
         # SQS — job queue + DLQ
         # -------------------
-        dlq = sqs.Queue(
+        self.dlq = sqs.Queue(
             self,
             "AgentJobDLQ",
             retention_period=cdk.Duration.days(14),
@@ -73,7 +73,7 @@ class NeptuneAgentStack(cdk.Stack):
             self,
             "AgentJobQueue",
             visibility_timeout=cdk.Duration.seconds(360),  # > worker Lambda timeout
-            dead_letter_queue=sqs.DeadLetterQueue(max_receive_count=2, queue=dlq),
+            dead_letter_queue=sqs.DeadLetterQueue(max_receive_count=2, queue=self.dlq),
         )
 
         # -------------------

--- a/src/neptune_agent_stack.py
+++ b/src/neptune_agent_stack.py
@@ -72,7 +72,7 @@ class NeptuneAgentStack(cdk.Stack):
         self.job_queue = sqs.Queue(
             self,
             "AgentJobQueue",
-            visibility_timeout=cdk.Duration.seconds(120),  # > worker Lambda timeout
+            visibility_timeout=cdk.Duration.seconds(360),  # > worker Lambda timeout
             dead_letter_queue=sqs.DeadLetterQueue(max_receive_count=2, queue=dlq),
         )
 
@@ -161,7 +161,9 @@ class NeptuneAgentStack(cdk.Stack):
                 "BEDROCK_MODEL_ID": bedrock_model_id,
                 "JOB_TABLE_NAME": self.job_table.table_name,
             },
-            timeout=cdk.Duration.seconds(90),  # agent loops can be slow
+            timeout=cdk.Duration.seconds(
+                300
+            ),  # up to 3 Neptune queries × 80s poll each + Bedrock overhead
             memory_size=512,
             # Cap concurrency to avoid overwhelming Bedrock/Neptune under burst traffic
             reserved_concurrent_executions=10,

--- a/src/neptune_api_stack.py
+++ b/src/neptune_api_stack.py
@@ -61,7 +61,7 @@ class NeptuneApiStack(cdk.Stack):
         # -------------------
         # SQS — query job queue + DLQ
         # -------------------
-        dlq = sqs.Queue(
+        self.dlq = sqs.Queue(
             self,
             "QueryJobDLQ",
             retention_period=cdk.Duration.days(14),
@@ -70,7 +70,7 @@ class NeptuneApiStack(cdk.Stack):
             self,
             "QueryJobQueue",
             visibility_timeout=cdk.Duration.seconds(90),  # > worker Lambda timeout
-            dead_letter_queue=sqs.DeadLetterQueue(max_receive_count=2, queue=dlq),
+            dead_letter_queue=sqs.DeadLetterQueue(max_receive_count=2, queue=self.dlq),
         )
 
         # -------------------

--- a/src/neptune_api_stack.py
+++ b/src/neptune_api_stack.py
@@ -1,15 +1,34 @@
 import aws_cdk as cdk
 from aws_cdk import aws_apigateway as apigw
+from aws_cdk import aws_dynamodb as dynamodb
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as lambda_
+from aws_cdk import aws_lambda_event_sources as lambda_event_sources
 from aws_cdk import aws_logs as logs
+from aws_cdk import aws_sqs as sqs
 from constructs import Construct
+
+_BUNDLING = cdk.BundlingOptions(
+    image=lambda_.Runtime.PYTHON_3_11.bundling_image,
+    command=[
+        "bash",
+        "-c",
+        "pip install -r requirements.txt -t /asset-output && cp -r . /asset-output",
+    ],
+)
 
 
 class NeptuneApiStack(cdk.Stack):
     """
-    Public read-only API for Neptune via API Gateway + Lambda
+    Public read-only API for Neptune via async job pattern.
+
+    Flow:
+      POST /query  →  submit Lambda  →  SQS  →  worker Lambda (query.py)  →  DynamoDB
+      GET /query/{job_id}  →  status Lambda  →  DynamoDB
+
+    Decouples HTTP from SPARQL execution so Neptune's 40s+ complex queries
+    don't hit API Gateway's 29s hard timeout.
     """
 
     def __init__(
@@ -25,7 +44,37 @@ class NeptuneApiStack(cdk.Stack):
         super().__init__(scope, construct_id, **kwargs)
 
         # -------------------
-        # Lambda Security Group
+        # DynamoDB — query job store
+        # -------------------
+        self.job_table = dynamodb.Table(
+            self,
+            "QueryJobTable",
+            table_name=f"{construct_id}-query-jobs",
+            partition_key=dynamodb.Attribute(
+                name="job_id", type=dynamodb.AttributeType.STRING
+            ),
+            billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
+            time_to_live_attribute="ttl",
+            removal_policy=cdk.RemovalPolicy.DESTROY,
+        )
+
+        # -------------------
+        # SQS — query job queue + DLQ
+        # -------------------
+        dlq = sqs.Queue(
+            self,
+            "QueryJobDLQ",
+            retention_period=cdk.Duration.days(14),
+        )
+        self.job_queue = sqs.Queue(
+            self,
+            "QueryJobQueue",
+            visibility_timeout=cdk.Duration.seconds(90),  # > worker Lambda timeout
+            dead_letter_queue=sqs.DeadLetterQueue(max_receive_count=2, queue=dlq),
+        )
+
+        # -------------------
+        # Lambda security group (worker needs VPC to reach Neptune)
         # -------------------
         self.lambda_sg = ec2.SecurityGroup(
             self,
@@ -35,25 +84,61 @@ class NeptuneApiStack(cdk.Stack):
             allow_all_outbound=True,
         )
 
+        ec2.CfnSecurityGroupIngress(
+            self,
+            "LambdaToNeptuneIngress",
+            group_id=neptune_security_group.security_group_id,
+            ip_protocol="tcp",
+            from_port=8182,
+            to_port=8182,
+            source_security_group_id=self.lambda_sg.security_group_id,
+        )
+
         # -------------------
-        # Lambda Function
+        # Submit Lambda — POST /query (no VPC needed)
+        # -------------------
+        self.submit_fn = lambda_.Function(
+            self,
+            "NeptuneQuerySubmitFunction",
+            runtime=lambda_.Runtime.PYTHON_3_11,
+            handler="submit.handler",
+            code=lambda_.Code.from_asset("src/lambda", bundling=_BUNDLING),
+            environment={
+                "JOB_TABLE_NAME": self.job_table.table_name,
+                "JOB_QUEUE_URL": self.job_queue.queue_url,
+            },
+            timeout=cdk.Duration.seconds(10),
+            memory_size=256,
+        )
+        self.job_table.grant_write_data(self.submit_fn)
+        self.job_queue.grant_send_messages(self.submit_fn)
+
+        # -------------------
+        # Status Lambda — GET /query/{job_id} (no VPC needed)
+        # -------------------
+        self.status_fn = lambda_.Function(
+            self,
+            "NeptuneQueryStatusFunction",
+            runtime=lambda_.Runtime.PYTHON_3_11,
+            handler="status.handler",
+            code=lambda_.Code.from_asset("src/lambda", bundling=_BUNDLING),
+            environment={
+                "JOB_TABLE_NAME": self.job_table.table_name,
+            },
+            timeout=cdk.Duration.seconds(10),
+            memory_size=256,
+        )
+        self.job_table.grant_read_data(self.status_fn)
+
+        # -------------------
+        # Worker Lambda — SQS-triggered SPARQL executor (needs VPC)
         # -------------------
         self.query_fn = lambda_.Function(
             self,
             "NeptuneQueryFunction",
             runtime=lambda_.Runtime.PYTHON_3_11,
             handler="query.handler",
-            code=lambda_.Code.from_asset(
-                "src/lambda",
-                bundling=cdk.BundlingOptions(
-                    image=lambda_.Runtime.PYTHON_3_11.bundling_image,
-                    command=[
-                        "bash",
-                        "-c",
-                        "pip install -r requirements.txt -t /asset-output && cp -r . /asset-output",
-                    ],
-                ),
-            ),
+            code=lambda_.Code.from_asset("src/lambda", bundling=_BUNDLING),
             vpc=vpc,
             security_groups=[self.lambda_sg],
             vpc_subnets=ec2.SubnetSelection(
@@ -61,13 +146,20 @@ class NeptuneApiStack(cdk.Stack):
             ),
             environment={
                 "NEPTUNE_ENDPOINT": neptune_read_endpoint,
+                "JOB_TABLE_NAME": self.job_table.table_name,
             },
-            timeout=cdk.Duration.seconds(30),
+            timeout=cdk.Duration.seconds(75),  # Neptune complex queries can take 40s+
+            memory_size=512,
+        )
+        self.job_table.grant_read_write_data(self.query_fn)
+        self.query_fn.add_event_source(
+            lambda_event_sources.SqsEventSource(
+                self.job_queue,
+                batch_size=1,
+            )
         )
 
-        # -------------------
         # IAM: read-only Neptune access scoped to this cluster
-        # -------------------
         self.query_fn.add_to_role_policy(
             iam.PolicyStatement(
                 effect=iam.Effect.ALLOW,
@@ -80,18 +172,6 @@ class NeptuneApiStack(cdk.Stack):
                     f"arn:{self.partition}:neptune-db:{self.region}:{self.account}:{neptune_cluster_resource_id}/*"
                 ],
             )
-        )
-
-        # Allow Lambda to reach Neptune on port 8182.
-        # Use CfnSecurityGroupIngress (owned by this stack) to avoid a cross-stack cyclic reference.
-        ec2.CfnSecurityGroupIngress(
-            self,
-            "LambdaToNeptuneIngress",
-            group_id=neptune_security_group.security_group_id,
-            ip_protocol="tcp",
-            from_port=8182,
-            to_port=8182,
-            source_security_group_id=self.lambda_sg.security_group_id,
         )
 
         # -------------------
@@ -107,11 +187,11 @@ class NeptuneApiStack(cdk.Stack):
             self,
             "NeptuneApi",
             rest_api_name="neptune-query-api",
-            description="Read-only public API for Neptune graph queries",
+            description="Async read-only API for Neptune graph queries",
             cloud_watch_role=True,
             default_cors_preflight_options=apigw.CorsOptions(
                 allow_origins=apigw.Cors.ALL_ORIGINS,
-                allow_methods=["POST", "OPTIONS"],
+                allow_methods=["POST", "GET", "OPTIONS"],
             ),
             deploy_options=apigw.StageOptions(
                 access_log_destination=apigw.LogGroupLogDestination(access_log_group),
@@ -136,7 +216,13 @@ class NeptuneApiStack(cdk.Stack):
         query_resource = self.api.root.add_resource("query")
         query_resource.add_method(
             "POST",
-            apigw.LambdaIntegration(self.query_fn),
+            apigw.LambdaIntegration(self.submit_fn, timeout=cdk.Duration.seconds(10)),
+        )
+
+        query_job_resource = query_resource.add_resource("{job_id}")
+        query_job_resource.add_method(
+            "GET",
+            apigw.LambdaIntegration(self.status_fn, timeout=cdk.Duration.seconds(10)),
         )
 
         # -------------------
@@ -146,5 +232,17 @@ class NeptuneApiStack(cdk.Stack):
             self,
             "ApiUrl",
             value=f"{self.api.url}query",
-            description="Neptune read-only query API endpoint",
+            description='Submit endpoint — POST {"query": "..."}  →  {"job_id": "...", "status": "pending"}',
+        )
+        cdk.CfnOutput(
+            self,
+            "QueryJobStatusUrl",
+            value=f"{self.api.url}query/{{job_id}}",
+            description="Poll endpoint — GET /query/{job_id}",
+        )
+        cdk.CfnOutput(
+            self,
+            "QueryJobTableName",
+            value=self.job_table.table_name,
+            description="DynamoDB table storing query job results",
         )

--- a/tests/unit/test_monitoring_stack.py
+++ b/tests/unit/test_monitoring_stack.py
@@ -106,7 +106,7 @@ def test_query_dlq_alarm_threshold_is_one(template):
     template.has_resource_properties(
         "AWS::CloudWatch::Alarm",
         {
-            "AlarmDescription": "Query jobs landing in DLQ — all 3 attempts failed",
+            "AlarmDescription": "Query jobs landing in DLQ — all 2 attempts failed",
             "Threshold": 1,
             "EvaluationPeriods": 1,
             "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -119,7 +119,7 @@ def test_agent_dlq_alarm_threshold_is_one(template):
     template.has_resource_properties(
         "AWS::CloudWatch::Alarm",
         {
-            "AlarmDescription": "Agent jobs landing in DLQ — all 3 attempts failed",
+            "AlarmDescription": "Agent jobs landing in DLQ — all 2 attempts failed",
             "Threshold": 1,
             "EvaluationPeriods": 1,
             "ComparisonOperator": "GreaterThanOrEqualToThreshold",

--- a/tests/unit/test_monitoring_stack.py
+++ b/tests/unit/test_monitoring_stack.py
@@ -1,0 +1,164 @@
+import aws_cdk as cdk
+import pytest
+from aws_cdk import aws_apigateway as apigw
+from aws_cdk import aws_dynamodb as dynamodb
+from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_lambda as lambda_
+from aws_cdk import aws_sqs as sqs
+from aws_cdk.assertions import Template
+
+from src.monitoring_stack import MonitoringStack
+
+
+@pytest.fixture
+def template():
+    app = cdk.App()
+
+    # VPC (shared across helper stacks)
+    vpc_stack = cdk.Stack(app, "TestVpc")
+    ec2.Vpc(vpc_stack, "Vpc", max_azs=2)
+
+    # Stub stack — all supporting resources live here to keep MonitoringStack isolated
+    stub = cdk.Stack(app, "Stubs")
+
+    def _fn(name: str) -> lambda_.Function:
+        return lambda_.Function(
+            stub,
+            name,
+            runtime=lambda_.Runtime.PYTHON_3_11,
+            handler="index.handler",
+            code=lambda_.Code.from_inline("def handler(e, c): pass"),
+        )
+
+    def _queue(name: str) -> sqs.Queue:
+        return sqs.Queue(stub, name)
+
+    def _table(name: str) -> dynamodb.Table:
+        return dynamodb.Table(
+            stub,
+            name,
+            partition_key=dynamodb.Attribute(
+                name="job_id", type=dynamodb.AttributeType.STRING
+            ),
+        )
+
+    def _api(name: str, api_name: str) -> apigw.RestApi:
+        api = apigw.RestApi(stub, name, rest_api_name=api_name)
+        # RestApi requires at least one method to pass CDK validation
+        api.root.add_method("GET", apigw.MockIntegration())
+        return api
+
+    query_api = _api("QueryApi", "neptune-query-api")
+    agent_api = _api("AgentApi", "neptune-agent-api")
+
+    stack = MonitoringStack(
+        app,
+        "TestMonitoringStack",
+        query_api=query_api,
+        query_submit_fn=_fn("QSubmit"),
+        query_status_fn=_fn("QStatus"),
+        query_worker_fn=_fn("QWorker"),
+        query_job_queue=_queue("QQueue"),
+        query_dlq=_queue("QDLQ"),
+        query_job_table=_table("QTable"),
+        agent_api=agent_api,
+        agent_submit_fn=_fn("ASubmit"),
+        agent_status_fn=_fn("AStatus"),
+        agent_worker_fn=_fn("AWorker"),
+        agent_job_queue=_queue("AQueue"),
+        agent_dlq=_queue("ADLQ"),
+        agent_job_table=_table("ATable"),
+        neptune_cluster_id="cluster-TESTCLUSTERID",
+    )
+    return Template.from_stack(stack)
+
+
+# ---------------------------------------------------------------------------
+# Dashboard
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_created(template):
+    template.resource_count_is("AWS::CloudWatch::Dashboard", 1)
+
+
+def test_dashboard_name_contains_stack_id(template):
+    template.has_resource_properties(
+        "AWS::CloudWatch::Dashboard",
+        {"DashboardName": "TestMonitoringStack-overview"},
+    )
+
+
+def test_dashboard_url_output_exists(template):
+    template.has_output("DashboardUrl", {})
+
+
+# ---------------------------------------------------------------------------
+# Alarms
+# ---------------------------------------------------------------------------
+
+
+def test_two_dlq_alarms_created(template):
+    template.resource_count_is("AWS::CloudWatch::Alarm", 2)
+
+
+def test_query_dlq_alarm_threshold_is_one(template):
+    template.has_resource_properties(
+        "AWS::CloudWatch::Alarm",
+        {
+            "AlarmDescription": "Query jobs landing in DLQ — all 3 attempts failed",
+            "Threshold": 1,
+            "EvaluationPeriods": 1,
+            "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+            "TreatMissingData": "notBreaching",
+        },
+    )
+
+
+def test_agent_dlq_alarm_threshold_is_one(template):
+    template.has_resource_properties(
+        "AWS::CloudWatch::Alarm",
+        {
+            "AlarmDescription": "Agent jobs landing in DLQ — all 3 attempts failed",
+            "Threshold": 1,
+            "EvaluationPeriods": 1,
+            "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+            "TreatMissingData": "notBreaching",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dashboard body — key widget presence
+# ---------------------------------------------------------------------------
+
+
+def _dashboard_body(template) -> str:
+    dashboards = template.find_resources("AWS::CloudWatch::Dashboard")
+    assert len(dashboards) == 1
+    props = next(iter(dashboards.values()))["Properties"]
+    return props["DashboardBody"]["Fn::Join"][1]  # CDK serialises as Fn::Join
+
+
+def test_dashboard_contains_query_api_section(template):
+    parts = _dashboard_body(template)
+    combined = "".join(str(p) for p in parts)
+    assert "Query API" in combined
+
+
+def test_dashboard_contains_agent_api_section(template):
+    parts = _dashboard_body(template)
+    combined = "".join(str(p) for p in parts)
+    assert "Agent API" in combined
+
+
+def test_dashboard_contains_neptune_section(template):
+    parts = _dashboard_body(template)
+    combined = "".join(str(p) for p in parts)
+    assert "Neptune" in combined
+
+
+def test_dashboard_references_neptune_cluster_id(template):
+    parts = _dashboard_body(template)
+    combined = "".join(str(p) for p in parts)
+    assert "cluster-TESTCLUSTERID" in combined

--- a/tests/unit/test_query_handler.py
+++ b/tests/unit/test_query_handler.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 LAMBDA_DIR = str(Path(__file__).parents[2] / "src" / "lambda")
 if LAMBDA_DIR not in sys.path:
@@ -17,14 +18,24 @@ def set_env(monkeypatch):
         "NEPTUNE_ENDPOINT", "test-neptune.cluster.us-east-1.neptune.amazonaws.com"
     )
     monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("JOB_TABLE_NAME", "test-job-table")
 
 
 @pytest.fixture
-def handler():
+def mock_table():
+    table = MagicMock()
+    with patch("boto3.resource") as mock_resource:
+        mock_resource.return_value.Table.return_value = table
+        yield table
+
+
+@pytest.fixture
+def handler(mock_table):
     sys.modules.pop("query", None)
     import query as q
 
     importlib.reload(q)
+    q._dynamodb.Table.return_value = mock_table
     return q.handler
 
 
@@ -37,195 +48,219 @@ def sparql_response(body: dict, status: int = 200):
     return mock
 
 
-def make_event(body: dict | None = None):
-    return {"body": json.dumps(body) if body is not None else None}
+def make_sqs_event(*jobs):
+    """Build a minimal SQS event with one record per job dict."""
+    return {"Records": [{"body": json.dumps(job)} for job in jobs]}
+
+
+def default_job(**overrides):
+    base = {
+        "job_id": "abc-123",
+        "query": "SELECT * WHERE { ?s ?p ?o } LIMIT 5",
+        "source": "direct",
+        "source_ip": "1.2.3.4",
+        "user_agent": "test-agent",
+    }
+    base.update(overrides)
+    return base
 
 
 # ---------------------------------------------------------------------------
-# Success path
+# Status transitions — pending → running → complete
 # ---------------------------------------------------------------------------
 
 
 @patch("query.requests.post")
 @patch("query.SigV4Auth")
 @patch("query.botocore.session.Session")
-def test_success_returns_200(mock_session, mock_sigv4, mock_post, handler):
-    mock_post.return_value = sparql_response({"results": {"bindings": []}})
-
-    response = handler(make_event({"query": "SELECT * WHERE { ?s ?p ?o } LIMIT 1"}), {})
-
-    assert response["statusCode"] == 200
-
-
-@patch("query.requests.post")
-@patch("query.SigV4Auth")
-@patch("query.botocore.session.Session")
-def test_success_forwards_neptune_content_type(
-    mock_session, mock_sigv4, mock_post, handler
+def test_sets_running_before_neptune_call(
+    mock_session, mock_sigv4, mock_post, handler, mock_table
 ):
     mock_post.return_value = sparql_response({"results": {"bindings": []}})
 
-    response = handler(make_event({"query": "SELECT * WHERE { ?s ?p ?o } LIMIT 1"}), {})
+    handler(make_sqs_event(default_job()), {})
 
-    assert response["headers"]["Content-Type"] == "application/sparql-results+json"
-
-
-@patch("query.requests.post")
-@patch("query.SigV4Auth")
-@patch("query.botocore.session.Session")
-def test_success_includes_cors_header(mock_session, mock_sigv4, mock_post, handler):
-    mock_post.return_value = sparql_response({"results": {"bindings": []}})
-
-    response = handler(make_event({"query": "SELECT * WHERE { ?s ?p ?o } LIMIT 1"}), {})
-
-    assert response["headers"]["Access-Control-Allow-Origin"] == "*"
+    calls = mock_table.update_item.call_args_list
+    # First update must be status=running
+    first_values = calls[0].kwargs["ExpressionAttributeValues"]
+    assert first_values[":status"] == "running"
 
 
 @patch("query.requests.post")
 @patch("query.SigV4Auth")
 @patch("query.botocore.session.Session")
-def test_default_query_used_when_none_provided(
-    mock_session, mock_sigv4, mock_post, handler
+def test_sets_complete_with_results_on_success(
+    mock_session, mock_sigv4, mock_post, handler, mock_table
+):
+    result_body = {"results": {"bindings": [{"s": {"value": "x"}}]}}
+    mock_post.return_value = sparql_response(result_body)
+
+    handler(make_sqs_event(default_job()), {})
+
+    calls = mock_table.update_item.call_args_list
+    final_values = calls[-1].kwargs["ExpressionAttributeValues"]
+    assert final_values[":status"] == "complete"
+    assert json.loads(final_values[":results"]) == result_body
+
+
+@patch("query.requests.post")
+@patch("query.SigV4Auth")
+@patch("query.botocore.session.Session")
+def test_sets_complete_with_content_type(
+    mock_session, mock_sigv4, mock_post, handler, mock_table
 ):
     mock_post.return_value = sparql_response({"results": {"bindings": []}})
 
-    response = handler(make_event({}), {})
+    handler(make_sqs_event(default_job()), {})
 
-    assert response["statusCode"] == 200
-    called_body = (
-        mock_post.call_args.kwargs.get("data") or mock_post.call_args.args[1]
-        if mock_post.call_args.args
-        else mock_post.call_args.kwargs["data"]
+    final_values = mock_table.update_item.call_args_list[-1].kwargs[
+        "ExpressionAttributeValues"
+    ]
+    assert final_values[":content_type"] == "application/sparql-results+json"
+
+
+@patch("query.requests.post")
+@patch("query.SigV4Auth")
+@patch("query.botocore.session.Session")
+def test_sets_error_on_neptune_http_error(
+    mock_session, mock_sigv4, mock_post, handler, mock_table
+):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 400
+    mock_resp.headers = {}
+    mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "bad request", response=mock_resp
     )
-    assert "SELECT" in called_body
+    mock_post.return_value = mock_resp
+
+    with pytest.raises(requests.exceptions.HTTPError):  # noqa: F821
+        handler(make_sqs_event(default_job()), {})
+
+    final_values = mock_table.update_item.call_args_list[-1].kwargs[
+        "ExpressionAttributeValues"
+    ]
+    assert final_values[":status"] == "error"
+    assert "bad request" in final_values[":error"]
 
 
 @patch("query.requests.post")
 @patch("query.SigV4Auth")
 @patch("query.botocore.session.Session")
-def test_null_body_uses_default_query(mock_session, mock_sigv4, mock_post, handler):
-    mock_post.return_value = sparql_response({"results": {"bindings": []}})
+def test_sets_error_on_unexpected_exception(
+    mock_session, mock_sigv4, mock_post, handler, mock_table
+):
+    mock_post.side_effect = Exception("connection refused")
 
-    response = handler({"body": None}, {})
+    with pytest.raises(Exception, match="connection refused"):
+        handler(make_sqs_event(default_job()), {})
 
-    assert response["statusCode"] == 200
-
-
-# ---------------------------------------------------------------------------
-# Query length guard
-# ---------------------------------------------------------------------------
-
-
-def test_query_exceeding_max_length_returns_400(handler):
-    response = handler(make_event({"query": "S" * 8001}), {})
-
-    assert response["statusCode"] == 400
-    assert "exceeds maximum length" in json.loads(response["body"])["error"]
-
-
-def test_query_exceeding_max_length_includes_cors(handler):
-    response = handler(make_event({"query": "S" * 8001}), {})
-
-    assert response["headers"]["Access-Control-Allow-Origin"] == "*"
-
-
-def test_query_at_exact_max_length_is_accepted(handler):
-    with patch("query.requests.post") as mock_post, patch("query.SigV4Auth"), patch(
-        "query.botocore.session.Session"
-    ):
-        mock_post.return_value = sparql_response({"results": {"bindings": []}})
-        response = handler(make_event({"query": "S" * 8000}), {})
-
-    assert response["statusCode"] == 200
+    final_values = mock_table.update_item.call_args_list[-1].kwargs[
+        "ExpressionAttributeValues"
+    ]
+    assert final_values[":status"] == "error"
+    assert "connection refused" in final_values[":error"]
 
 
 # ---------------------------------------------------------------------------
-# Request construction
+# DynamoDB key — job_id is threaded through correctly
 # ---------------------------------------------------------------------------
 
 
 @patch("query.requests.post")
 @patch("query.SigV4Auth")
 @patch("query.botocore.session.Session")
-def test_neptune_called_with_post(mock_session, mock_sigv4, mock_post, handler):
+def test_update_item_uses_correct_job_id(
+    mock_session, mock_sigv4, mock_post, handler, mock_table
+):
     mock_post.return_value = sparql_response({"results": {"bindings": []}})
 
-    handler(make_event({"query": "SELECT * WHERE { ?s ?p ?o } LIMIT 1"}), {})
+    handler(make_sqs_event(default_job(job_id="job-xyz")), {})
+
+    for c in mock_table.update_item.call_args_list:
+        assert c.kwargs["Key"] == {"job_id": "job-xyz"}
+
+
+# ---------------------------------------------------------------------------
+# Neptune request construction
+# ---------------------------------------------------------------------------
+
+
+@patch("query.requests.post")
+@patch("query.SigV4Auth")
+@patch("query.botocore.session.Session")
+def test_neptune_called_with_sparql_query(
+    mock_session, mock_sigv4, mock_post, handler, mock_table
+):
+    mock_post.return_value = sparql_response({"results": {"bindings": []}})
+    query_str = "SELECT * WHERE { ?s ?p ?o } LIMIT 5"
+
+    handler(make_sqs_event(default_job(query=query_str)), {})
+
+    from urllib.parse import unquote_plus
 
     mock_post.assert_called_once()
-    # requests.post is the only HTTP method used — assert no other method called
-    assert mock_post.call_count == 1
+    sent_body = mock_post.call_args.kwargs.get("data") or mock_post.call_args[1].get(
+        "data"
+    )
+    assert query_str in unquote_plus(sent_body)
 
 
 @patch("query.requests.post")
 @patch("query.SigV4Auth")
 @patch("query.botocore.session.Session")
-def test_sigv4_auth_is_applied(mock_session, mock_sigv4, mock_post, handler):
+def test_sigv4_auth_applied(mock_session, mock_sigv4, mock_post, handler, mock_table):
     mock_post.return_value = sparql_response({"results": {"bindings": []}})
 
-    handler(make_event({"query": "SELECT * WHERE { ?s ?p ?o } LIMIT 1"}), {})
+    handler(make_sqs_event(default_job()), {})
 
     mock_sigv4.assert_called_once()
     mock_sigv4.return_value.add_auth.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
-# Invalid JSON body
-# ---------------------------------------------------------------------------
-
-
-def test_invalid_json_body_returns_400(handler):
-    response = handler({"body": "not valid json"}, {})
-
-    assert response["statusCode"] == 400
-    assert "valid JSON" in json.loads(response["body"])["error"]
-
-
-def test_invalid_json_includes_cors(handler):
-    response = handler({"body": "not valid json"}, {})
-
-    assert response["headers"]["Access-Control-Allow-Origin"] == "*"
-
-
-# ---------------------------------------------------------------------------
-# Neptune HTTP error
+# Optional SQS message fields default correctly
 # ---------------------------------------------------------------------------
 
 
 @patch("query.requests.post")
 @patch("query.SigV4Auth")
 @patch("query.botocore.session.Session")
-def test_neptune_http_error_returns_upstream_status(
-    mock_session, mock_sigv4, mock_post, handler
+def test_missing_optional_fields_default(
+    mock_session, mock_sigv4, mock_post, handler, mock_table
 ):
-    import requests
+    """source/source_ip/user_agent are optional in the SQS message."""
+    mock_post.return_value = sparql_response({"results": {"bindings": []}})
+    minimal_job = {"job_id": "min-1", "query": "SELECT * WHERE { ?s ?p ?o } LIMIT 1"}
 
-    mock_resp = MagicMock()
-    mock_resp.status_code = 400
-    mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
-        "bad request", response=mock_resp
-    )
-    mock_post.return_value = mock_resp
+    # Should not raise
+    handler(make_sqs_event(minimal_job), {})
 
-    response = handler(make_event({"query": "SELECT * WHERE { ?s ?p ?o }"}), {})
-
-    assert response["statusCode"] == 400
-    assert response["headers"]["Access-Control-Allow-Origin"] == "*"
+    final_values = mock_table.update_item.call_args_list[-1].kwargs[
+        "ExpressionAttributeValues"
+    ]
+    assert final_values[":status"] == "complete"
 
 
 # ---------------------------------------------------------------------------
-# Unexpected exception
+# Batch: multiple SQS records processed in one invocation
 # ---------------------------------------------------------------------------
 
 
 @patch("query.requests.post")
 @patch("query.SigV4Auth")
 @patch("query.botocore.session.Session")
-def test_unexpected_exception_returns_500(mock_session, mock_sigv4, mock_post, handler):
-    mock_post.side_effect = Exception("connection refused")
+def test_processes_multiple_records(
+    mock_session, mock_sigv4, mock_post, handler, mock_table
+):
+    mock_post.return_value = sparql_response({"results": {"bindings": []}})
+    job_a = default_job(job_id="job-a")
+    job_b = default_job(job_id="job-b")
 
-    response = handler(make_event({"query": "SELECT * WHERE { ?s ?p ?o }"}), {})
+    handler(make_sqs_event(job_a, job_b), {})
 
-    assert response["statusCode"] == 500
-    assert "connection refused" in json.loads(response["body"])["error"]
-    assert response["headers"]["Access-Control-Allow-Origin"] == "*"
+    assert mock_post.call_count == 2
+    job_ids_written = [
+        c.kwargs["Key"]["job_id"] for c in mock_table.update_item.call_args_list
+    ]
+    assert "job-a" in job_ids_written
+    assert "job-b" in job_ids_written

--- a/tests/unit/test_query_handler.py
+++ b/tests/unit/test_query_handler.py
@@ -228,8 +228,10 @@ def test_neptune_url_uses_endpoint_env_var(
     handler(make_sqs_event(default_job()), {})
 
     called_url = mock_post.call_args.kwargs.get("url") or mock_post.call_args[0][0]
-    assert "test-neptune.cluster.us-east-1.neptune.amazonaws.com" in called_url
-    assert called_url.endswith("/sparql")
+    assert (
+        called_url
+        == "https://test-neptune.cluster.us-east-1.neptune.amazonaws.com:8182/sparql"
+    )
 
 
 @patch("query.requests.post")

--- a/tests/unit/test_query_handler.py
+++ b/tests/unit/test_query_handler.py
@@ -217,6 +217,40 @@ def test_sigv4_auth_applied(mock_session, mock_sigv4, mock_post, handler, mock_t
     mock_sigv4.return_value.add_auth.assert_called_once()
 
 
+@patch("query.requests.post")
+@patch("query.SigV4Auth")
+@patch("query.botocore.session.Session")
+def test_neptune_url_uses_endpoint_env_var(
+    mock_session, mock_sigv4, mock_post, handler, mock_table
+):
+    mock_post.return_value = sparql_response({"results": {"bindings": []}})
+
+    handler(make_sqs_event(default_job()), {})
+
+    called_url = mock_post.call_args.kwargs.get("url") or mock_post.call_args[0][0]
+    assert "test-neptune.cluster.us-east-1.neptune.amazonaws.com" in called_url
+    assert called_url.endswith("/sparql")
+
+
+@patch("query.requests.post")
+@patch("query.SigV4Auth")
+@patch("query.botocore.session.Session")
+def test_duration_ms_stored_as_decimal(
+    mock_session, mock_sigv4, mock_post, handler, mock_table
+):
+    """DynamoDB rejects plain floats — _update_job must convert them to Decimal."""
+    from decimal import Decimal
+
+    mock_post.return_value = sparql_response({"results": {"bindings": []}})
+
+    handler(make_sqs_event(default_job()), {})
+
+    final_values = mock_table.update_item.call_args_list[-1].kwargs[
+        "ExpressionAttributeValues"
+    ]
+    assert isinstance(final_values[":duration_ms"], Decimal)
+
+
 # ---------------------------------------------------------------------------
 # Optional SQS message fields default correctly
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Depends on #17 

Neptune knowledge graph queries will definitely take longer than a second. Because of this, it is best to set up an asynchronous API so that these API post calls won't time out on the client side - leading to non-reactive client side implementations