### PR TITLE
Add get schema tool

### DIFF
--- a/src/lambda_agent/agent.py
+++ b/src/lambda_agent/agent.py
@@ -29,10 +29,11 @@ You have access to a Neptune RDF graph containing biomedical data about genes, d
 pathways, and their relationships, described using standard ontologies (e.g. RDF/OWL, SPARQL).
 
 When a user asks a question:
-1. Formulate a SPARQL SELECT query to answer it.
-2. Call the query_neptune tool with that query.
-3. Interpret the results and answer in plain language.
-4. If the first query returns no results or needs refinement, try an alternative query.
+1. Call get_schema to discover available classes and properties if you are unsure of the graph structure.
+2. Formulate a SPARQL SELECT query to answer the question.
+3. Call the query_neptune tool with that query.
+4. Interpret the results and answer in plain language.
+5. If the first query returns no results or needs refinement, try an alternative query.
 
 Always explain what you found and how confident you are in the answer.
 """
@@ -115,6 +116,40 @@ def query_neptune(sparql: str) -> str:
     raise TimeoutError(timeout_msg)
 
 
+_SCHEMA_SPARQL = """\
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?term ?kind ?label ?comment ?domain ?range WHERE {
+    {
+        ?term a owl:Class .
+        BIND("Class" AS ?kind)
+    } UNION {
+        ?term a owl:ObjectProperty .
+        BIND("ObjectProperty" AS ?kind)
+    } UNION {
+        ?term a owl:DatatypeProperty .
+        BIND("DatatypeProperty" AS ?kind)
+    }
+    OPTIONAL { ?term rdfs:label ?label }
+    OPTIONAL { ?term rdfs:comment ?comment }
+    OPTIONAL { ?term rdfs:domain ?domain }
+    OPTIONAL { ?term rdfs:range ?range }
+} ORDER BY ?kind ?term"""
+
+
+@tool
+def get_schema() -> str:
+    """Return all classes and properties defined in the knowledge graph ontology.
+
+    Use this to discover the graph structure (available types and predicates)
+    before writing SPARQL queries.
+    Returns a JSON string with 'results.bindings' rows containing term, kind,
+    label, comment, domain, and range fields.
+    """
+    return query_neptune(_SCHEMA_SPARQL)
+
+
 def _update_job(job_id: str, **fields):
     table = _dynamodb.Table(DYNAMODB_TABLE)
     update_expr = "SET " + ", ".join(f"#{k} = :{k}" for k in fields)
@@ -188,7 +223,7 @@ def _process_job(job_id: str, question: str):
     agent = Agent(
         model=model,
         system_prompt=SYSTEM_PROMPT,
-        tools=[query_neptune],
+        tools=[query_neptune, get_schema],
     )
 
     try:

--- a/src/lambda_agent/agent.py
+++ b/src/lambda_agent/agent.py
@@ -31,7 +31,9 @@ _PREFIX_STRIP_RE = re.compile(
 
 def _safe_sparql(sparql: str) -> str:
     """Reject non-SELECT queries."""
-    clean = re.sub(r"#[^\n]*", "", sparql)  # strip line comments before keyword scan
+    clean = re.sub(
+        r"(?m)^\s*#[^\n]*\n?", "", sparql
+    )  # strip full-line comments only (# inside IRIs must survive)
     body = _PREFIX_STRIP_RE.sub("", clean).lstrip()
     if not body.upper().startswith("SELECT"):
         first = body.split()[0] if body.split() else "(empty)"

--- a/src/lambda_agent/agent.py
+++ b/src/lambda_agent/agent.py
@@ -26,10 +26,12 @@ _dynamodb = boto3.resource("dynamodb")
 
 SYSTEM_PROMPT = """You are a biomedical knowledge graph assistant for the Sage Brain project.
 You have access to a Neptune RDF graph containing biomedical data about genes, diseases,
-pathways, and their relationships, described using standard ontologies (e.g. RDF/OWL, SPARQL).
+pathways, and their relationships. The primary ontology namespace is
+<http://nf-osi.github.com/terms#> (prefix: nf:).
 
 When a user asks a question:
 1. Call get_schema to discover available classes and properties if you are unsure of the graph structure.
+   Pass a namespace_prefix to scope results to a specific ontology.
 2. Formulate a SPARQL SELECT query to answer the question.
 3. Call the query_neptune tool with that query.
 4. Interpret the results and answer in plain language.
@@ -116,38 +118,50 @@ def query_neptune(sparql: str) -> str:
     raise TimeoutError(timeout_msg)
 
 
-_SCHEMA_SPARQL = """\
+_SCHEMA_SPARQL_BASE = """\
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?term ?kind ?label ?comment ?domain ?range WHERE {
-    {
+SELECT ?term ?kind ?label ?comment ?domain ?range WHERE {{
+    {{
         ?term a owl:Class .
         BIND("Class" AS ?kind)
-    } UNION {
+    }} UNION {{
         ?term a owl:ObjectProperty .
         BIND("ObjectProperty" AS ?kind)
-    } UNION {
+    }} UNION {{
         ?term a owl:DatatypeProperty .
         BIND("DatatypeProperty" AS ?kind)
-    }
-    OPTIONAL { ?term rdfs:label ?label }
-    OPTIONAL { ?term rdfs:comment ?comment }
-    OPTIONAL { ?term rdfs:domain ?domain }
-    OPTIONAL { ?term rdfs:range ?range }
-} ORDER BY ?kind ?term"""
+    }}
+    OPTIONAL {{ ?term rdfs:label ?label }}
+    OPTIONAL {{ ?term rdfs:comment ?comment }}
+    OPTIONAL {{ ?term rdfs:domain ?domain }}
+    OPTIONAL {{ ?term rdfs:range ?range }}
+    {filter}
+}} ORDER BY ?kind ?term"""
 
 
 @tool
-def get_schema() -> str:
+def get_schema(namespace_prefix: str = "") -> str:
     """Return all classes and properties defined in the knowledge graph ontology.
 
     Use this to discover the graph structure (available types and predicates)
     before writing SPARQL queries.
+
+    Args:
+        namespace_prefix: Optional IRI prefix to filter results to a specific
+            ontology (e.g. "http://nf-osi.github.com/terms#"). Leave empty
+            to return terms from all loaded ontologies.
+
     Returns a JSON string with 'results.bindings' rows containing term, kind,
     label, comment, domain, and range fields.
     """
-    return query_neptune(_SCHEMA_SPARQL)
+    if namespace_prefix:
+        filter_clause = f'FILTER(STRSTARTS(STR(?term), "{namespace_prefix}"))'
+    else:
+        filter_clause = ""
+    sparql = _SCHEMA_SPARQL_BASE.format(filter=filter_clause)
+    return query_neptune(sparql)
 
 
 def _update_job(job_id: str, **fields):

--- a/src/lambda_agent/agent.py
+++ b/src/lambda_agent/agent.py
@@ -24,7 +24,7 @@ QUERY_POLL_TIMEOUT = (
 )
 # After stripping PREFIX declarations, the query must begin with SELECT.
 _PREFIX_STRIP_RE = re.compile(
-    r"^\s*(PREFIX\s+\S+\s*<[^>]*>\s*)*",
+    r"^\s*(PREFIX\s+\S+\s*<[^>]*>\s*(#[^\n]*)?\s*)*",
     re.IGNORECASE,
 )
 

--- a/src/lambda_agent/agent.py
+++ b/src/lambda_agent/agent.py
@@ -1,6 +1,7 @@
 import json
 import os
 import random
+import re
 import time
 from decimal import Decimal
 
@@ -21,6 +22,22 @@ QUERY_POLL_INTERVAL = 3  # seconds between polls
 QUERY_POLL_TIMEOUT = (
     70  # seconds before giving up; Neptune query worker has 75s timeout
 )
+# After stripping PREFIX declarations, the query must begin with SELECT.
+_PREFIX_STRIP_RE = re.compile(
+    r"^\s*(PREFIX\s+\S+\s*<[^>]*>\s*)*",
+    re.IGNORECASE,
+)
+
+
+def _safe_sparql(sparql: str) -> str:
+    """Reject non-SELECT queries."""
+    clean = re.sub(r"#[^\n]*", "", sparql)  # strip line comments before keyword scan
+    body = _PREFIX_STRIP_RE.sub("", clean).lstrip()
+    if not body.upper().startswith("SELECT"):
+        first = body.split()[0] if body.split() else "(empty)"
+        raise ValueError(f"Only SPARQL SELECT queries are permitted; got {first!r}.")
+    return sparql
+
 
 _dynamodb = boto3.resource("dynamodb")
 
@@ -31,7 +48,7 @@ pathways, and their relationships. The primary ontology namespace is
 
 When a user asks a question:
 1. Call get_schema to discover available classes and properties if you are unsure of the graph structure.
-   Pass a namespace_prefix to scope results to a specific ontology.
+   Pass a namespace — one of "nf-osi", "obo", "efo", or "edam".
 2. Formulate a SPARQL SELECT query to answer the question.
 3. Call the query_neptune tool with that query.
 4. Interpret the results and answer in plain language.
@@ -58,6 +75,7 @@ def query_neptune(sparql: str) -> str:
     """Execute a SPARQL SELECT query against the Neptune biomedical knowledge graph.
     Returns results as a JSON string with 'results.bindings' containing the rows.
     Use standard SPARQL 1.1 syntax with PREFIX declarations."""
+    sparql = _safe_sparql(sparql)
     _steps.append({"type": "tool_call", "tool": "query_neptune", "sparql": sparql})
     _flush_steps()
     if _current_job_id:
@@ -148,31 +166,40 @@ SELECT DISTINCT ?term ?kind ?label ?comment ?domain ?range WHERE {{
     {filter}
 }} ORDER BY ?kind ?term"""
 
+# Allowed namespace prefixes surfaced to the agent as discrete choices.
+KNOWN_NAMESPACES = {
+    "nf-osi": "http://nf-osi.github.com/terms#",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "efo": "http://www.ebi.ac.uk/efo/",
+    "edam": "http://edamontology.org/",
+}
+
 
 @tool
-def get_schema(namespace_prefix: str = "") -> str:
-    """Return all classes and properties defined in the knowledge graph ontology.
+def get_schema(namespace: str) -> str:
+    """Return all classes and properties defined in the knowledge graph ontology
+    for a specific namespace.
 
     Use this to discover the graph structure (available types and predicates)
     before writing SPARQL queries.
 
     Args:
-        namespace_prefix: Optional IRI prefix to filter results to a specific
-            ontology (e.g. "http://nf-osi.github.com/terms#"). Leave empty
-            to return terms from all loaded ontologies.
+        namespace: The ontology namespace to inspect. Must be one of:
+            - "nf-osi" → http://nf-osi.github.com/terms#
+            - "obo"    → http://purl.obolibrary.org/obo/
+            - "efo"    → http://www.ebi.ac.uk/efo/
+            - "edam"   → http://edamontology.org/
 
     Returns a JSON string with 'results.bindings' rows containing term, kind,
     label, comment, domain, and range fields.
     """
-    if namespace_prefix:
-        if not namespace_prefix.startswith(("http://", "https://")):
-            raise ValueError(
-                f"namespace_prefix must be an HTTP(S) IRI, got: {namespace_prefix!r}"
-            )
-        safe_prefix = namespace_prefix.replace("\\", "").replace('"', "")
-        filter_clause = f'FILTER(STRSTARTS(STR(?term), "{safe_prefix}"))'
-    else:
-        filter_clause = ""
+    if namespace not in KNOWN_NAMESPACES:
+        raise ValueError(
+            f"Unknown namespace {namespace!r}. "
+            f"Must be one of: {', '.join(sorted(KNOWN_NAMESPACES))}."
+        )
+    prefix_iri = KNOWN_NAMESPACES[namespace]
+    filter_clause = f'FILTER(STRSTARTS(STR(?term), "{prefix_iri}"))'
     sparql = _SCHEMA_SPARQL_BASE.format(filter=filter_clause)
     return query_neptune(sparql)
 

--- a/src/lambda_agent/agent.py
+++ b/src/lambda_agent/agent.py
@@ -119,12 +119,16 @@ def query_neptune(sparql: str) -> str:
 
 
 _SCHEMA_SPARQL_BASE = """\
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?term ?kind ?label ?comment ?domain ?range WHERE {{
+SELECT DISTINCT ?term ?kind ?label ?comment ?domain ?range WHERE {{
     {{
         ?term a owl:Class .
+        BIND("Class" AS ?kind)
+    }} UNION {{
+        ?term a rdfs:Class .
         BIND("Class" AS ?kind)
     }} UNION {{
         ?term a owl:ObjectProperty .
@@ -132,7 +136,11 @@ SELECT ?term ?kind ?label ?comment ?domain ?range WHERE {{
     }} UNION {{
         ?term a owl:DatatypeProperty .
         BIND("DatatypeProperty" AS ?kind)
+    }} UNION {{
+        ?term a rdf:Property .
+        BIND("Property" AS ?kind)
     }}
+    FILTER(isIRI(?term))
     OPTIONAL {{ ?term rdfs:label ?label }}
     OPTIONAL {{ ?term rdfs:comment ?comment }}
     OPTIONAL {{ ?term rdfs:domain ?domain }}
@@ -157,7 +165,12 @@ def get_schema(namespace_prefix: str = "") -> str:
     label, comment, domain, and range fields.
     """
     if namespace_prefix:
-        filter_clause = f'FILTER(STRSTARTS(STR(?term), "{namespace_prefix}"))'
+        if not namespace_prefix.startswith(("http://", "https://")):
+            raise ValueError(
+                f"namespace_prefix must be an HTTP(S) IRI, got: {namespace_prefix!r}"
+            )
+        safe_prefix = namespace_prefix.replace("\\", "").replace('"', "")
+        filter_clause = f'FILTER(STRSTARTS(STR(?term), "{safe_prefix}"))'
     else:
         filter_clause = ""
     sparql = _SCHEMA_SPARQL_BASE.format(filter=filter_clause)

--- a/tests/unit/test_safe_sparql.py
+++ b/tests/unit/test_safe_sparql.py
@@ -1,0 +1,80 @@
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+LAMBDA_AGENT_DIR = str(Path(__file__).parents[2] / "src" / "lambda_agent")
+if LAMBDA_AGENT_DIR not in sys.path:
+    sys.path.insert(0, LAMBDA_AGENT_DIR)
+
+# Extract just the pure-Python logic under test — no AWS/Strands needed.
+_PREFIX_STRIP_RE = re.compile(
+    r"^\s*(PREFIX\s+\S+\s*<[^>]*>\s*(#[^\n]*)?\s*)*",
+    re.IGNORECASE,
+)
+
+
+def _safe_sparql(sparql: str) -> str:
+    clean = re.sub(r"(?m)^\s*#[^\n]*\n?", "", sparql)
+    body = _PREFIX_STRIP_RE.sub("", clean).lstrip()
+    if not body.upper().startswith("SELECT"):
+        first = body.split()[0] if body.split() else "(empty)"
+        raise ValueError(f"Only SPARQL SELECT queries are permitted; got {first!r}.")
+    return sparql
+
+
+class TestSafeSparql:
+    def test_simple_select_passes(self):
+        q = "SELECT ?s WHERE { ?s ?p ?o } LIMIT 5"
+        assert _safe_sparql(q) == q
+
+    def test_select_with_prefix_passes(self):
+        q = "PREFIX nf: <http://nf-osi.github.com/terms#>\nSELECT ?s WHERE { ?s a nf:Gene }"
+        assert _safe_sparql(q) == q
+
+    def test_hash_inside_iri_not_stripped(self):
+        """IRI containing # must survive — this was the original bug."""
+        q = (
+            "PREFIX nf: <http://nf-osi.github.com/terms#>\n"
+            "SELECT ?s WHERE { ?s a nf:Gene }"
+        )
+        result = _safe_sparql(q)
+        assert "<http://nf-osi.github.com/terms#>" in result
+
+    def test_leading_line_comment_stripped_for_keyword_scan(self):
+        """Full-line comments before SELECT must not block the SELECT check."""
+        q = "# find all genes\nSELECT ?s WHERE { ?s ?p ?o }"
+        assert _safe_sparql(q) == q
+
+    def test_indented_line_comment_stripped(self):
+        q = "  # indented comment\nSELECT ?s WHERE { ?s ?p ?o }"
+        assert _safe_sparql(q) == q
+
+    def test_prefix_with_inline_comment_passes(self):
+        """Trailing # comment on a PREFIX line must not block the SELECT check."""
+        q = (
+            "PREFIX nf: <http://nf-osi.github.com/terms#> # nf-osi namespace\n"
+            "SELECT ?s WHERE { ?s a nf:Gene }"
+        )
+        assert _safe_sparql(q) == q
+
+    def test_multiple_prefixes_with_inline_comments_pass(self):
+        q = (
+            "PREFIX nf: <http://nf-osi.github.com/terms#> # nf-osi\n"
+            "PREFIX obo: <http://purl.obolibrary.org/obo/> # OBO\n"
+            "SELECT ?s WHERE { ?s a nf:Gene }"
+        )
+        assert _safe_sparql(q) == q
+
+    def test_construct_rejected(self):
+        with pytest.raises(ValueError, match="SELECT"):
+            _safe_sparql("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }")
+
+    def test_insert_rejected(self):
+        with pytest.raises(ValueError, match="SELECT"):
+            _safe_sparql("INSERT DATA { <a> <b> <c> }")
+
+    def test_empty_query_rejected(self):
+        with pytest.raises(ValueError):
+            _safe_sparql("")


### PR DESCRIPTION
Fixes #25 

Add a get_schema tool to neptune AND also allow the tool to query for the different namespaces while providing direction. 

In the future, we will probably look to add more namespaces, so we should probably decide on a "namespace" standard before this gets added