### PR TITLE
Add Synapse team-gated token authorizer to query and agent APIs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,10 @@ jobs:
         uses: actions/setup-python@v6
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-dev.txt
+      - name: Set up QEMU for ARM64 Docker builds
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
       - name: Run unit tests
         run: python -m pytest tests/ -s -v
   synth:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # sage-brain-infra
 
-AWS CDK (Python) infrastructure for the Sage Brain project. Deploys an Amazon Neptune graph database with a public read-only API (API Gateway + Lambda), a Bedrock Strands AI agent API, and SageMaker Studio for team data loading.
+AWS CDK (Python) infrastructure for the Sage Brain project. Deploys an Amazon Neptune graph database with a Synapse-authenticated read-only API (API Gateway + Lambda), a Bedrock Strands AI agent API, and SageMaker Studio for team data loading.
 
 ## AWS Profile
 
@@ -104,11 +104,12 @@ Test with curl:
 # Submit
 JOB=$(curl -s -X POST <ApiUrl> \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <synapse-pat>" \
   -d '{"query": "SELECT * WHERE { ?s ?p ?o } LIMIT 5"}')
 JOB_ID=$(echo $JOB | python3 -c "import sys,json; print(json.load(sys.stdin)['job_id'])")
 
 # Poll
-curl <ApiUrl>/$JOB_ID
+curl -H "Authorization: Bearer <synapse-pat>" <ApiUrl>/$JOB_ID
 ```
 
 ## Agent API: src/lambda_agent/ (async job pattern)
@@ -155,11 +156,12 @@ Test with curl:
 # Submit
 JOB=$(curl -s -X POST <AgentApiUrl> \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <synapse-pat>" \
   -d '{"question": "What types of biological entities are in this knowledge graph?"}')
 JOB_ID=$(echo $JOB | python3 -c "import sys,json; print(json.load(sys.stdin)['job_id'])")
 
 # Poll
-curl <AgentApiUrl>/$JOB_ID
+curl -H "Authorization: Bearer <synapse-pat>" <AgentApiUrl>/$JOB_ID
 ```
 
 ## API Gateway
@@ -170,13 +172,13 @@ curl <AgentApiUrl>/$JOB_ID
 - **Access logs**: CloudWatch log group with 1-month retention (every request, structured JSON)
 - **Execution logs**: ERROR level only
 - **CloudWatch role**: set via `cloud_watch_role=True` on `RestApi`
-- No authentication — intentionally public read-only; throttling + IAM read-only scope are the mitigations
+- **Auth**: Synapse token authorizer (Lambda) — caller must present a valid Synapse PAT/OAuth token and be a member of Synapse team 273957. Result cached 5 min per token.
 
 ### app-dev-neptune-agent (`POST /ask`, `GET /ask/{job_id}`)
 - **Throttling**: 50 RPS steady-state, 100 burst (lightweight — no Bedrock/Neptune calls inline)
 - **Timeout**: 10s integration timeout (submit/status are fast; agent runs async in worker)
 - **Access logs**: CloudWatch log group with 1-month retention
-- No authentication — same public posture as `/query`
+- **Auth**: same Synapse token authorizer as `/query`
 
 ## Query Audit Logging
 
@@ -222,7 +224,7 @@ Tests live in `tests/unit/`. Lambda handler tests import from `src/lambda/` via 
 - Neptune security group has **no broad ingress rules**. Each consumer stack (Lambda, SageMaker) adds a targeted SG-to-SG `CfnSecurityGroupIngress` rule on port 8182 to avoid cross-stack cyclic references.
 - The API Lambda uses the **read endpoint** only, scoped to read-only IAM actions.
 - The API is **POST only** — GET was removed to avoid URL length limits for complex SPARQL queries.
-- **No auth planned** — the API is intentionally public; throttling and read-only IAM are the mitigations.
+- **Synapse team-gated auth** — both APIs require a valid Synapse PAT/OAuth token and membership in team 273957. The Lambda authorizer validates via Synapse's `/userProfile` + `/team/{id}/member/{userId}/membershipStatus` endpoints; results are cached 5 min by API Gateway.
 - **S3 bulk loader** is used for all data loading — not SPARQL INSERT batches. Neptune assumes `NeptuneLoadRole` (trusted by `rds.amazonaws.com`) to read from S3.
 - **Date-partitioned S3 layout** (`YYYY-MM-DD/schema/` and `YYYY-MM-DD/data/rdf/`) preserves a historical data lake. Each load is a full reset + reload from a chosen prefix.
 - **SageMaker Studio** runs in `VpcOnly` mode so notebook kernels can reach Neptune. Requires VPC interface endpoints for `sagemaker.api` and `sts` (in NetworkStack).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ AWS CDK infrastructure for the Sage Brain project, deploying an Amazon Neptune g
 
 - **VPC Networking**: Isolated network environment with public and private subnets
 - **Amazon Neptune**: Managed graph database for knowledge graphs
-- **Public SPARQL API**: Read-only API Gateway + Lambda endpoint for querying Neptune over HTTPS
+- **SPARQL API**: Read-only API Gateway + Lambda endpoint for querying Neptune over HTTPS (Synapse team-gated)
 - **AI Agent API**: Natural-language query interface powered by Bedrock Strands (Claude Sonnet 4.6) — converts plain-language questions to SPARQL and returns answers with full reasoning trace
 - **SageMaker Studio**: Team JupyterLab environment for loading and querying the knowledge graph
 - **Query Audit Logging**: All SPARQL queries logged to CloudWatch with source tracking (direct vs. agent)
@@ -116,7 +116,7 @@ AWS_PROFILE=sagebrain cdk deploy app-dev-neptune-sagemaker --context env=dev
 
 ### Direct SPARQL (`POST /query`)
 
-A read-only SPARQL endpoint is available over HTTPS — no authentication required.
+A read-only SPARQL endpoint is available over HTTPS. Requests must include a Synapse Personal Access Token (PAT) and the caller must be a member of Synapse team [273957](https://www.synapse.org/Team:273957).
 
 Get the API URL from CDK outputs after deployment:
 
@@ -132,6 +132,7 @@ Send a `POST` request with a JSON body containing your SPARQL query:
 ```console
 curl -X POST <API_URL> \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your-synapse-pat>" \
   -d '{"query": "SELECT * WHERE { ?s ?p ?o } LIMIT 10"}'
 ```
 
@@ -155,6 +156,7 @@ Send a `POST` request with a `question` field:
 ```console
 curl -X POST <AGENT_URL> \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your-synapse-pat>" \
   -d '{"question": "What types of biological entities are in this knowledge graph?"}'
 ```
 

--- a/app.py
+++ b/app.py
@@ -60,6 +60,7 @@ neptune_api_stack = NeptuneApiStack(
     neptune_cluster_resource_id=neptune_stack.neptune_cluster.attr_cluster_resource_id,
     neptune_security_group=neptune_stack.neptune_security_group,
     synapse_team_id=config["AUTH"]["synapse_team_id"],
+    machine_api_key=config["AUTH"].get("machine_api_key", ""),
     env=env,
 )
 # Note: No explicit dependency needed as the direct references create implicit dependencies
@@ -72,6 +73,7 @@ neptune_agent_stack = NeptuneAgentStack(
     neptune_query_url=f"{neptune_api_stack.api.url}query",
     neptune_query_status_url=f"{neptune_api_stack.api.url}query",
     synapse_team_id=config["AUTH"]["synapse_team_id"],
+    machine_api_key=config["AUTH"].get("machine_api_key", ""),
     env=env,
 )
 

--- a/app.py
+++ b/app.py
@@ -59,6 +59,7 @@ neptune_api_stack = NeptuneApiStack(
     neptune_read_endpoint=neptune_stack.neptune_cluster.attr_read_endpoint,
     neptune_cluster_resource_id=neptune_stack.neptune_cluster.attr_cluster_resource_id,
     neptune_security_group=neptune_stack.neptune_security_group,
+    synapse_team_id=config["AUTH"]["synapse_team_id"],
     env=env,
 )
 # Note: No explicit dependency needed as the direct references create implicit dependencies
@@ -70,6 +71,7 @@ neptune_agent_stack = NeptuneAgentStack(
     vpc=network_stack.vpc,
     neptune_query_url=f"{neptune_api_stack.api.url}query",
     neptune_query_status_url=f"{neptune_api_stack.api.url}query",
+    synapse_team_id=config["AUTH"]["synapse_team_id"],
     env=env,
 )
 

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -22,3 +22,4 @@ NEPTUNE_SAGEMAKER:
 
 AUTH:
   synapse_team_id: "273957"
+  # machine_api_key: ""  # set in env-specific config (not committed); enables x-api-key auth

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -19,3 +19,6 @@ NEPTUNE:
 NEPTUNE_SAGEMAKER:
   enabled: true
   domain_name: "sage-brain-studio"
+
+AUTH:
+  synapse_team_id: "273957"

--- a/src/lambda/submit.py
+++ b/src/lambda/submit.py
@@ -1,9 +1,13 @@
 import json
+import logging
 import os
 import time
 import uuid
 
 import boto3
+
+log = logging.getLogger()
+log.setLevel(logging.INFO)
 
 DYNAMODB_TABLE = os.environ["JOB_TABLE_NAME"]
 SQS_QUEUE_URL = os.environ["JOB_QUEUE_URL"]
@@ -20,6 +24,10 @@ JOB_TTL_SECONDS = 86400  # 24 hours
 
 
 def handler(event, context):
+    user_id = (
+        event.get("requestContext", {}).get("authorizer", {}).get("user_id", "unknown")
+    )
+
     try:
         body = json.loads(event.get("body") or "{}")
         query = body.get("query", "").strip()
@@ -77,6 +85,18 @@ def handler(event, context):
                 "user_agent": headers.get("User-Agent", "unknown"),
             }
         ),
+    )
+
+    log.info(
+        json.dumps(
+            {
+                "event": "query_submitted",
+                "job_id": job_id,
+                "user_id": user_id,
+                "source_ip": source_ip,
+                "source": headers.get("X-Source", "direct"),
+            }
+        )
     )
 
     return {

--- a/src/lambda_agent/agent.py
+++ b/src/lambda_agent/agent.py
@@ -40,6 +40,7 @@ Always explain what you found and how confident you are in the answer.
 # Module-level state reset per invocation.
 _steps: list = []
 _current_job_id: str = ""
+_auth_header: str = ""
 
 
 def _flush_steps():
@@ -63,11 +64,13 @@ def query_neptune(sparql: str) -> str:
             status_detail=f"Executing SPARQL query (step {len(_steps)})...",
         )
 
+    auth_headers = {"X-Source": "agent", "Authorization": _auth_header}
+
     # Submit job
     submit_response = requests.post(
         NEPTUNE_QUERY_URL,
         json={"query": sparql},
-        headers={"X-Source": "agent"},
+        headers=auth_headers,
         timeout=10,
     )
     submit_response.raise_for_status()
@@ -79,6 +82,7 @@ def query_neptune(sparql: str) -> str:
         time.sleep(QUERY_POLL_INTERVAL)
         poll = requests.get(
             f"{NEPTUNE_QUERY_STATUS_URL}/{job_id}",
+            headers=auth_headers,
             timeout=10,
         )
         poll.raise_for_status()
@@ -176,10 +180,11 @@ def _invoke_agent_with_retry(agent, question: str, job_id: str):
                 raise
 
 
-def _process_job(job_id: str, question: str):
-    global _steps, _current_job_id
+def _process_job(job_id: str, question: str, authorization: str):
+    global _steps, _current_job_id, _auth_header
     _steps = []
     _current_job_id = job_id
+    _auth_header = authorization
     start = time.time()
 
     _update_job(job_id, status="running")
@@ -244,4 +249,5 @@ def handler(event, context):
         body = json.loads(record["body"])
         job_id = body["job_id"]
         question = body["question"]
-        _process_job(job_id, question)
+        authorization = body.get("authorization", "")
+        _process_job(job_id, question, authorization)

--- a/src/lambda_agent/submit.py
+++ b/src/lambda_agent/submit.py
@@ -69,9 +69,13 @@ def handler(event, context):
         }
     )
 
+    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
+    auth_header = headers.get("authorization", "")
     _sqs.send_message(
         QueueUrl=SQS_QUEUE_URL,
-        MessageBody=json.dumps({"job_id": job_id, "question": question}),
+        MessageBody=json.dumps(
+            {"job_id": job_id, "question": question, "authorization": auth_header}
+        ),
     )
 
     source_ip = (

--- a/src/lambda_agent/submit.py
+++ b/src/lambda_agent/submit.py
@@ -1,9 +1,13 @@
 import json
+import logging
 import os
 import time
 import uuid
 
 import boto3
+
+log = logging.getLogger()
+log.setLevel(logging.INFO)
 
 DYNAMODB_TABLE = os.environ["JOB_TABLE_NAME"]
 SQS_QUEUE_URL = os.environ["JOB_QUEUE_URL"]
@@ -20,6 +24,10 @@ JOB_TTL_SECONDS = 86400  # 24 hours
 
 
 def handler(event, context):
+    user_id = (
+        event.get("requestContext", {}).get("authorizer", {}).get("user_id", "unknown")
+    )
+
     try:
         body = json.loads(event.get("body") or "{}")
         question = body.get("question", "").strip()
@@ -64,6 +72,20 @@ def handler(event, context):
     _sqs.send_message(
         QueueUrl=SQS_QUEUE_URL,
         MessageBody=json.dumps({"job_id": job_id, "question": question}),
+    )
+
+    source_ip = (
+        event.get("requestContext", {}).get("identity", {}).get("sourceIp", "unknown")
+    )
+    log.info(
+        json.dumps(
+            {
+                "event": "question_submitted",
+                "job_id": job_id,
+                "user_id": user_id,
+                "source_ip": source_ip,
+            }
+        )
     )
 
     return {

--- a/src/lambda_authorizer/authorizer.py
+++ b/src/lambda_authorizer/authorizer.py
@@ -86,15 +86,45 @@ def _validate_synapse_token(token: str) -> str:
         if time.monotonic() < expires_at:
             return principal_id
 
-    user_id = _userinfo(token)
-    _check_team_membership(token, user_id)
+    user_id = _get_synapse_user_id(token)
+    _check_team_membership(user_id)
 
     _token_cache[token] = (user_id, time.monotonic() + _CACHE_TTL)
     return user_id
 
 
-def _userinfo(token: str) -> str:
-    """Validate token via Synapse OIDC userinfo (accepts both PATs and OAuth JWTs)."""
+def _get_synapse_user_id(token: str) -> str:
+    """Return the numeric Synapse user ID for any valid token type.
+
+    Tries /userProfile first (PATs and OAuth tokens with the 'view' scope).
+    Falls back to OIDC userinfo for OAuth tokens that only carry 'openid' scope.
+    The OIDC 'sub' claim is pairwise-opaque per client and cannot be used for
+    team membership checks — only the 'userid' claim carries the numeric ID.
+    """
+    req = urllib.request.Request(
+        f"{SYNAPSE_REPO_API}/userProfile",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read())
+        user_id = data.get("ownerId")
+        if not user_id:
+            raise _AuthDenied("unauthenticated")
+        return str(user_id)
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            raise _AuthDenied("invalid token") from e
+        if e.code == 403:
+            # OAuth token lacks the 'view' scope required by /userProfile.
+            # Fall back to OIDC userinfo which only needs 'openid'.
+            return _userinfo_oidc(token)
+        raise
+
+
+def _userinfo_oidc(token: str) -> str:
+    """Get numeric Synapse user ID via OIDC userinfo for OAuth-only tokens.
+    Uses the 'userid' claim — 'sub' is pairwise-opaque per client."""
     req = urllib.request.Request(
         f"{SYNAPSE_AUTH_API}/oauth2/userinfo",
         headers={"Authorization": f"Bearer {token}"},
@@ -106,23 +136,33 @@ def _userinfo(token: str) -> str:
         if e.code in (401, 403):
             raise _AuthDenied("invalid token") from e
         raise
-    user_id = data.get("sub") or data.get("userid")
+    user_id = data.get("userid")
+    log.info(
+        json.dumps(
+            {
+                "event": "oidc_userinfo",
+                "has_userid": user_id is not None,
+                "has_sub": data.get("sub") is not None,
+                "sub_preview": (data.get("sub") or "")[:8] or None,
+            }
+        )
+    )
     if not user_id:
         raise _AuthDenied("unauthenticated")
     return str(user_id)
 
 
-def _check_team_membership(token: str, user_id: str) -> None:
+def _check_team_membership(user_id: str) -> None:
+    # The membershipStatus endpoint is public — no auth required.
     req = urllib.request.Request(
         f"{SYNAPSE_REPO_API}/team/{TEAM_ID}/member/{user_id}/membershipStatus",
-        headers={"Authorization": f"Bearer {token}"},
     )
     try:
         with urllib.request.urlopen(req, timeout=5) as resp:
             data = json.loads(resp.read())
     except urllib.error.HTTPError as e:
-        if e.code in (401, 403):
-            raise _AuthDenied("invalid token on membership check") from e
+        if e.code in (400, 404):
+            raise _AuthDenied("not a team member") from e
         raise
     if not data.get("isMember"):
         raise _AuthDenied("not a team member")

--- a/src/lambda_authorizer/authorizer.py
+++ b/src/lambda_authorizer/authorizer.py
@@ -1,46 +1,102 @@
+import hmac
 import json
 import logging
 import os
+import time
 import urllib.error
 import urllib.request
 
 log = logging.getLogger()
 log.setLevel(logging.INFO)
 
-SYNAPSE_API = "https://repo-prod.prod.sagebase.org/repo/v1"
+SYNAPSE_AUTH_API = "https://repo-prod.prod.sagebase.org/auth/v1"
+SYNAPSE_REPO_API = "https://repo-prod.prod.sagebase.org/repo/v1"
+
 TEAM_ID = os.getenv("SYNAPSE_TEAM_ID")
 if not TEAM_ID:
     raise RuntimeError("Missing required environment variable: SYNAPSE_TEAM_ID")
 
+# Optional — if set, callers may authenticate with x-api-key: <key>.
+# Machine clients must ALSO send Authorization: ApiKey so API Gateway's identity
+# source requirement is satisfied (see RequestAuthorizer in the CDK stack).
+# Leave unset (or empty) to disable the API-key path.
+_MACHINE_API_KEY = os.getenv("MACHINE_API_KEY", "")
+
+# Lambda-instance token cache: token -> (principal_id, expires_monotonic)
+# Warm instances reuse this to avoid redundant Synapse API calls.
+_token_cache: dict = {}
+_CACHE_TTL = 300  # seconds
+
 
 class _AuthDenied(Exception):
-    """Expected auth failure — token invalid or user not in team.
-    Never include the token value in the message; it ends up in CloudWatch logs."""
+    """Expected auth failure. Never include the credential value in the message."""
 
 
 def handler(event, context):
-    raw_token = event.get("authorizationToken", "")
+    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
     method_arn = event["methodArn"]
 
     try:
-        if not raw_token.lower().startswith("bearer "):
-            raise _AuthDenied("missing or malformed Authorization header")
-        token = raw_token[7:]  # strip "Bearer " (case-insensitive, always 7 chars)
-        user_id = _validate_token(token)
-        _check_team_membership(token, user_id)
-        log.info(json.dumps({"event": "auth_allow", "user_id": user_id}))
-        return _policy(user_id, "Allow", method_arn)
+        principal = _authenticate(headers)
+        log.info(json.dumps({"event": "auth_allow", "principal": principal}))
+        return _policy(principal, "Allow", method_arn)
     except _AuthDenied as e:
         log.warning(json.dumps({"event": "auth_deny", "reason": str(e)}))
         return _policy("anonymous", "Deny", method_arn)
     # Transient errors (Synapse timeout / 5xx / network) propagate uncaught.
-    # API Gateway treats a Lambda error as Unauthorized (401) and does NOT
-    # cache the result, so valid users aren't locked out for the cache TTL.
+    # API Gateway treats a Lambda error as Unauthorized and does NOT cache the
+    # result, so valid users are not locked out during a Synapse outage.
 
 
-def _validate_token(token):
+def _authenticate(headers: dict) -> str:
+    api_key = headers.get("x-api-key", "")
+    auth = headers.get("authorization", "")
+
+    if api_key:
+        return _validate_api_key(api_key)
+
+    if auth.lower().startswith("bearer "):
+        return _validate_synapse_token(auth[7:])
+
+    raise _AuthDenied("no recognised credential (x-api-key or Authorization: Bearer)")
+
+
+# ---------------------------------------------------------------------------
+# API-key path  (machine / service clients)
+# ---------------------------------------------------------------------------
+
+
+def _validate_api_key(provided: str) -> str:
+    if not _MACHINE_API_KEY:
+        raise _AuthDenied("x-api-key auth not configured")
+    if not hmac.compare_digest(provided, _MACHINE_API_KEY):
+        raise _AuthDenied("invalid x-api-key")
+    return "machine"
+
+
+# ---------------------------------------------------------------------------
+# Synapse Bearer path  (PATs and OAuth JWTs both accepted)
+# ---------------------------------------------------------------------------
+
+
+def _validate_synapse_token(token: str) -> str:
+    cached = _token_cache.get(token)
+    if cached:
+        principal_id, expires_at = cached
+        if time.monotonic() < expires_at:
+            return principal_id
+
+    user_id = _userinfo(token)
+    _check_team_membership(token, user_id)
+
+    _token_cache[token] = (user_id, time.monotonic() + _CACHE_TTL)
+    return user_id
+
+
+def _userinfo(token: str) -> str:
+    """Validate token via Synapse OIDC userinfo (accepts both PATs and OAuth JWTs)."""
     req = urllib.request.Request(
-        f"{SYNAPSE_API}/userProfile",
+        f"{SYNAPSE_AUTH_API}/oauth2/userinfo",
         headers={"Authorization": f"Bearer {token}"},
     )
     try:
@@ -49,16 +105,16 @@ def _validate_token(token):
     except urllib.error.HTTPError as e:
         if e.code in (401, 403):
             raise _AuthDenied("invalid token") from e
-        raise  # 5xx or unexpected — let it propagate
-    # Synapse returns 200 + Anonymous profile for missing/invalid tokens
-    if data.get("userName") == "anonymous":
+        raise
+    user_id = data.get("sub") or data.get("userid")
+    if not user_id:
         raise _AuthDenied("unauthenticated")
-    return str(data["ownerId"])
+    return str(user_id)
 
 
-def _check_team_membership(token, user_id):
+def _check_team_membership(token: str, user_id: str) -> None:
     req = urllib.request.Request(
-        f"{SYNAPSE_API}/team/{TEAM_ID}/member/{user_id}/membershipStatus",
+        f"{SYNAPSE_REPO_API}/team/{TEAM_ID}/member/{user_id}/membershipStatus",
         headers={"Authorization": f"Bearer {token}"},
     )
     try:
@@ -72,9 +128,13 @@ def _check_team_membership(token, user_id):
         raise _AuthDenied("not a team member")
 
 
-def _policy(principal_id, effect, method_arn):
-    # Wildcard across all methods/stages so the cached policy covers both
-    # POST /query and GET /query/{job_id} without a separate authorizer call.
+# ---------------------------------------------------------------------------
+# Policy helper
+# ---------------------------------------------------------------------------
+
+
+def _policy(principal_id: str, effect: str, method_arn: str) -> dict:
+    # Wildcard across all methods/stages so one cached policy covers the whole API.
     parts = method_arn.split(":")
     region, account = parts[3], parts[4]
     api_id = parts[5].split("/")[0]
@@ -93,6 +153,6 @@ def _policy(principal_id, effect, method_arn):
             ],
         },
         # Passed to downstream Lambdas as event["requestContext"]["authorizer"].
-        # Never include the token here — context is visible in X-Ray traces.
+        # Never include the credential here — context is visible in X-Ray traces.
         "context": {"user_id": principal_id},
     }

--- a/src/lambda_authorizer/authorizer.py
+++ b/src/lambda_authorizer/authorizer.py
@@ -10,9 +10,7 @@ log.setLevel(logging.INFO)
 SYNAPSE_API = "https://repo-prod.prod.sagebase.org/repo/v1"
 TEAM_ID = os.getenv("SYNAPSE_TEAM_ID")
 if not TEAM_ID:
-    raise RuntimeError(
-        "Missing required environment variable: SYNAPSE_TEAM_ID"
-    )
+    raise RuntimeError("Missing required environment variable: SYNAPSE_TEAM_ID")
 
 
 class _AuthDenied(Exception):

--- a/src/lambda_authorizer/authorizer.py
+++ b/src/lambda_authorizer/authorizer.py
@@ -1,24 +1,39 @@
 import json
+import logging
 import os
 import urllib.error
 import urllib.request
 
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
 SYNAPSE_API = "https://repo-prod.prod.sagebase.org/repo/v1"
 TEAM_ID = os.environ["SYNAPSE_TEAM_ID"]
+
+
+class _AuthDenied(Exception):
+    """Expected auth failure — token invalid or user not in team.
+    Never include the token value in the message; it ends up in CloudWatch logs."""
 
 
 def handler(event, context):
     raw_token = event.get("authorizationToken", "")
     method_arn = event["methodArn"]
 
-    token = raw_token.removeprefix("Bearer ").removeprefix("bearer ")
-
     try:
+        if not raw_token.lower().startswith("bearer "):
+            raise _AuthDenied("missing or malformed Authorization header")
+        token = raw_token[7:]  # strip "Bearer " (case-insensitive, always 7 chars)
         user_id = _validate_token(token)
         _check_team_membership(token, user_id)
+        log.info(json.dumps({"event": "auth_allow", "user_id": user_id}))
         return _policy(user_id, "Allow", method_arn)
-    except Exception:
+    except _AuthDenied as e:
+        log.warning(json.dumps({"event": "auth_deny", "reason": str(e)}))
         return _policy("anonymous", "Deny", method_arn)
+    # Transient errors (Synapse timeout / 5xx / network) propagate uncaught.
+    # API Gateway treats a Lambda error as Unauthorized (401) and does NOT
+    # cache the result, so valid users aren't locked out for the cache TTL.
 
 
 def _validate_token(token):
@@ -26,24 +41,33 @@ def _validate_token(token):
         f"{SYNAPSE_API}/userProfile",
         headers={"Authorization": f"Bearer {token}"},
     )
-    with urllib.request.urlopen(req, timeout=5) as resp:
-        data = json.loads(resp.read())
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            raise _AuthDenied("invalid token") from e
+        raise  # 5xx or unexpected — let it propagate
     # Synapse returns 200 + Anonymous profile for missing/invalid tokens
     if data.get("userName") == "anonymous":
-        raise ValueError("unauthenticated")
+        raise _AuthDenied("unauthenticated")
     return str(data["ownerId"])
 
 
 def _check_team_membership(token, user_id):
-    """Raises if user is not a member of the required Synapse team."""
     req = urllib.request.Request(
         f"{SYNAPSE_API}/team/{TEAM_ID}/member/{user_id}/membershipStatus",
         headers={"Authorization": f"Bearer {token}"},
     )
-    with urllib.request.urlopen(req, timeout=5) as resp:
-        data = json.loads(resp.read())
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            raise _AuthDenied("invalid token on membership check") from e
+        raise
     if not data.get("isMember"):
-        raise ValueError("not a team member")
+        raise _AuthDenied("not a team member")
 
 
 def _policy(principal_id, effect, method_arn):
@@ -66,4 +90,7 @@ def _policy(principal_id, effect, method_arn):
                 }
             ],
         },
+        # Passed to downstream Lambdas as event["requestContext"]["authorizer"].
+        # Never include the token here — context is visible in X-Ray traces.
+        "context": {"user_id": principal_id},
     }

--- a/src/lambda_authorizer/authorizer.py
+++ b/src/lambda_authorizer/authorizer.py
@@ -8,7 +8,11 @@ log = logging.getLogger()
 log.setLevel(logging.INFO)
 
 SYNAPSE_API = "https://repo-prod.prod.sagebase.org/repo/v1"
-TEAM_ID = os.environ["SYNAPSE_TEAM_ID"]
+TEAM_ID = os.getenv("SYNAPSE_TEAM_ID")
+if not TEAM_ID:
+    raise RuntimeError(
+        "Missing required environment variable: SYNAPSE_TEAM_ID"
+    )
 
 
 class _AuthDenied(Exception):

--- a/src/lambda_authorizer/authorizer.py
+++ b/src/lambda_authorizer/authorizer.py
@@ -28,6 +28,9 @@ def _validate_token(token):
     )
     with urllib.request.urlopen(req, timeout=5) as resp:
         data = json.loads(resp.read())
+    # Synapse returns 200 + Anonymous profile for missing/invalid tokens
+    if data.get("userName") == "anonymous":
+        raise ValueError("unauthenticated")
     return str(data["ownerId"])
 
 

--- a/src/lambda_authorizer/authorizer.py
+++ b/src/lambda_authorizer/authorizer.py
@@ -1,0 +1,64 @@
+import json
+import os
+import urllib.error
+import urllib.request
+
+SYNAPSE_API = "https://repo-prod.prod.sagebase.org/repo/v1"
+TEAM_ID = os.environ["SYNAPSE_TEAM_ID"]
+
+
+def handler(event, context):
+    raw_token = event.get("authorizationToken", "")
+    method_arn = event["methodArn"]
+
+    token = raw_token.removeprefix("Bearer ").removeprefix("bearer ")
+
+    try:
+        user_id = _validate_token(token)
+        _check_team_membership(token, user_id)
+        return _policy(user_id, "Allow", method_arn)
+    except Exception:
+        return _policy("anonymous", "Deny", method_arn)
+
+
+def _validate_token(token):
+    req = urllib.request.Request(
+        f"{SYNAPSE_API}/userProfile",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        data = json.loads(resp.read())
+    return str(data["ownerId"])
+
+
+def _check_team_membership(token, user_id):
+    """Raises on non-200 (e.g. 404 = not a team member, 401 = bad token)."""
+    req = urllib.request.Request(
+        f"{SYNAPSE_API}/teamMember/{TEAM_ID}/{user_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        resp.read()
+
+
+def _policy(principal_id, effect, method_arn):
+    # Wildcard across all methods/stages so the cached policy covers both
+    # POST /query and GET /query/{job_id} without a separate authorizer call.
+    parts = method_arn.split(":")
+    region, account = parts[3], parts[4]
+    api_id = parts[5].split("/")[0]
+    resource = f"arn:aws:execute-api:{region}:{account}:{api_id}/*/*"
+
+    return {
+        "principalId": principal_id,
+        "policyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "execute-api:Invoke",
+                    "Effect": effect,
+                    "Resource": resource,
+                }
+            ],
+        },
+    }

--- a/src/lambda_authorizer/authorizer.py
+++ b/src/lambda_authorizer/authorizer.py
@@ -35,13 +35,15 @@ def _validate_token(token):
 
 
 def _check_team_membership(token, user_id):
-    """Raises on non-200 (e.g. 404 = not a team member, 401 = bad token)."""
+    """Raises if user is not a member of the required Synapse team."""
     req = urllib.request.Request(
-        f"{SYNAPSE_API}/teamMember/{TEAM_ID}/{user_id}",
+        f"{SYNAPSE_API}/team/{TEAM_ID}/member/{user_id}/membershipStatus",
         headers={"Authorization": f"Bearer {token}"},
     )
     with urllib.request.urlopen(req, timeout=5) as resp:
-        resp.read()
+        data = json.loads(resp.read())
+    if not data.get("isMember"):
+        raise ValueError("not a team member")
 
 
 def _policy(principal_id, effect, method_arn):

--- a/src/neptune_agent_stack.py
+++ b/src/neptune_agent_stack.py
@@ -41,6 +41,7 @@ class NeptuneAgentStack(cdk.Stack):
         vpc: ec2.Vpc,
         neptune_query_url: str,
         neptune_query_status_url: str,
+        synapse_team_id: str,
         bedrock_model_id: str = "us.anthropic.claude-sonnet-4-6",
         **kwargs,
     ) -> None:
@@ -192,6 +193,27 @@ class NeptuneAgentStack(cdk.Stack):
         )
 
         # -------------------
+        # Synapse token authorizer Lambda (no VPC — calls Synapse public API)
+        # -------------------
+        authorizer_fn = lambda_.Function(
+            self,
+            "SynapseAuthorizerFunction",
+            runtime=lambda_.Runtime.PYTHON_3_11,
+            handler="authorizer.handler",
+            code=lambda_.Code.from_asset("src/lambda_authorizer"),
+            environment={"SYNAPSE_TEAM_ID": synapse_team_id},
+            timeout=cdk.Duration.seconds(10),
+            memory_size=256,
+        )
+
+        token_authorizer = apigw.TokenAuthorizer(
+            self,
+            "SynapseTokenAuthorizer",
+            handler=authorizer_fn,
+            results_cache_ttl=cdk.Duration.minutes(5),
+        )
+
+        # -------------------
         # API Gateway
         # -------------------
         access_log_group = logs.LogGroup(
@@ -209,6 +231,7 @@ class NeptuneAgentStack(cdk.Stack):
             default_cors_preflight_options=apigw.CorsOptions(
                 allow_origins=apigw.Cors.ALL_ORIGINS,
                 allow_methods=["POST", "GET", "OPTIONS"],
+                allow_headers=["Content-Type", "Authorization", "X-Source"],
             ),
             deploy_options=apigw.StageOptions(
                 access_log_destination=apigw.LogGroupLogDestination(access_log_group),
@@ -234,12 +257,14 @@ class NeptuneAgentStack(cdk.Stack):
         ask_resource.add_method(
             "POST",
             apigw.LambdaIntegration(self.submit_fn, timeout=cdk.Duration.seconds(10)),
+            authorizer=token_authorizer,
         )
 
         ask_job_resource = ask_resource.add_resource("{job_id}")
         ask_job_resource.add_method(
             "GET",
             apigw.LambdaIntegration(self.status_fn, timeout=cdk.Duration.seconds(10)),
+            authorizer=token_authorizer,
         )
 
         # -------------------

--- a/src/neptune_agent_stack.py
+++ b/src/neptune_agent_stack.py
@@ -42,6 +42,7 @@ class NeptuneAgentStack(cdk.Stack):
         neptune_query_url: str,
         neptune_query_status_url: str,
         synapse_team_id: str,
+        machine_api_key: str = "",
         bedrock_model_id: str = "us.anthropic.claude-sonnet-4-6",
         **kwargs,
     ) -> None:
@@ -193,24 +194,35 @@ class NeptuneAgentStack(cdk.Stack):
         )
 
         # -------------------
-        # Synapse token authorizer Lambda (no VPC — calls Synapse public API)
+        # Authorizer Lambda — no VPC (calls Synapse public API)
+        # Accepts x-api-key header (machine clients) or Authorization: Bearer
+        # (Synapse PAT or OAuth JWT).  Machine clients must also send
+        # Authorization: ApiKey so API Gateway's identity-source check passes.
         # -------------------
+        authorizer_env = {"SYNAPSE_TEAM_ID": synapse_team_id}
+        if machine_api_key:
+            authorizer_env["MACHINE_API_KEY"] = machine_api_key
+
         authorizer_fn = lambda_.Function(
             self,
             "SynapseAuthorizerFunction",
             runtime=lambda_.Runtime.PYTHON_3_11,
             handler="authorizer.handler",
             code=lambda_.Code.from_asset("src/lambda_authorizer"),
-            environment={"SYNAPSE_TEAM_ID": synapse_team_id},
+            environment=authorizer_env,
             timeout=cdk.Duration.seconds(10),
             memory_size=256,
         )
 
-        token_authorizer = apigw.TokenAuthorizer(
+        # REQUEST authorizer so the Lambda can read both Authorization and
+        # x-api-key headers.  Caching is disabled here; the Lambda does its
+        # own in-process token cache (5 min TTL) for warm instances.
+        token_authorizer = apigw.RequestAuthorizer(
             self,
-            "SynapseTokenAuthorizer",
+            "SynapseRequestAuthorizer",
             handler=authorizer_fn,
-            results_cache_ttl=cdk.Duration.minutes(5),
+            identity_sources=[apigw.IdentitySource.header("Authorization")],
+            results_cache_ttl=cdk.Duration.seconds(0),
         )
 
         # -------------------
@@ -231,7 +243,12 @@ class NeptuneAgentStack(cdk.Stack):
             default_cors_preflight_options=apigw.CorsOptions(
                 allow_origins=apigw.Cors.ALL_ORIGINS,
                 allow_methods=["POST", "GET", "OPTIONS"],
-                allow_headers=["Content-Type", "Authorization", "X-Source"],
+                allow_headers=[
+                    "Content-Type",
+                    "Authorization",
+                    "X-Source",
+                    "x-api-key",
+                ],
             ),
             deploy_options=apigw.StageOptions(
                 access_log_destination=apigw.LogGroupLogDestination(access_log_group),

--- a/src/neptune_agent_stack.py
+++ b/src/neptune_agent_stack.py
@@ -253,6 +253,16 @@ class NeptuneAgentStack(cdk.Stack):
             ),
         )
 
+        # Remap 403 (Deny policy from token authorizer) → 401 so clients get a
+        # consistent Unauthorized response. CORS header included so browser
+        # clients can read the status code.
+        self.api.add_gateway_response(
+            "AccessDeniedAs401",
+            type=apigw.ResponseType.ACCESS_DENIED,
+            status_code="401",
+            response_headers={"Access-Control-Allow-Origin": "'*'"},
+        )
+
         ask_resource = self.api.root.add_resource("ask")
         ask_resource.add_method(
             "POST",

--- a/src/neptune_agent_stack.py
+++ b/src/neptune_agent_stack.py
@@ -262,6 +262,14 @@ class NeptuneAgentStack(cdk.Stack):
             status_code="401",
             response_headers={"Access-Control-Allow-Origin": "'*'"},
         )
+        # Missing/empty Authorization header → API GW returns UNAUTHORIZED before
+        # running the authorizer, which by default omits CORS headers. Browser
+        # clients need the header to read the 401 status.
+        self.api.add_gateway_response(
+            "UnauthorizedWithCors",
+            type=apigw.ResponseType.UNAUTHORIZED,
+            response_headers={"Access-Control-Allow-Origin": "'*'"},
+        )
 
         ask_resource = self.api.root.add_resource("ask")
         ask_resource.add_method(

--- a/src/neptune_api_stack.py
+++ b/src/neptune_api_stack.py
@@ -245,6 +245,14 @@ class NeptuneApiStack(cdk.Stack):
             status_code="401",
             response_headers={"Access-Control-Allow-Origin": "'*'"},
         )
+        # Missing/empty Authorization header → API GW returns UNAUTHORIZED before
+        # running the authorizer, which by default omits CORS headers. Browser
+        # clients need the header to read the 401 status.
+        self.api.add_gateway_response(
+            "UnauthorizedWithCors",
+            type=apigw.ResponseType.UNAUTHORIZED,
+            response_headers={"Access-Control-Allow-Origin": "'*'"},
+        )
 
         query_resource = self.api.root.add_resource("query")
         query_resource.add_method(

--- a/src/neptune_api_stack.py
+++ b/src/neptune_api_stack.py
@@ -236,6 +236,16 @@ class NeptuneApiStack(cdk.Stack):
             ),
         )
 
+        # Remap 403 (Deny policy from token authorizer) → 401 so clients get a
+        # consistent Unauthorized response. CORS header included so browser
+        # clients can read the status code.
+        self.api.add_gateway_response(
+            "AccessDeniedAs401",
+            type=apigw.ResponseType.ACCESS_DENIED,
+            status_code="401",
+            response_headers={"Access-Control-Allow-Origin": "'*'"},
+        )
+
         query_resource = self.api.root.add_resource("query")
         query_resource.add_method(
             "POST",

--- a/src/neptune_api_stack.py
+++ b/src/neptune_api_stack.py
@@ -40,6 +40,7 @@ class NeptuneApiStack(cdk.Stack):
         neptune_cluster_resource_id: str,
         neptune_security_group: ec2.SecurityGroup,
         synapse_team_id: str,
+        machine_api_key: str = "",
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -176,24 +177,35 @@ class NeptuneApiStack(cdk.Stack):
         )
 
         # -------------------
-        # Synapse token authorizer Lambda (no VPC — calls Synapse public API)
+        # Authorizer Lambda — no VPC (calls Synapse public API)
+        # Accepts x-api-key header (machine clients) or Authorization: Bearer
+        # (Synapse PAT or OAuth JWT).  Machine clients must also send
+        # Authorization: ApiKey so API Gateway's identity-source check passes.
         # -------------------
+        authorizer_env = {"SYNAPSE_TEAM_ID": synapse_team_id}
+        if machine_api_key:
+            authorizer_env["MACHINE_API_KEY"] = machine_api_key
+
         authorizer_fn = lambda_.Function(
             self,
             "SynapseAuthorizerFunction",
             runtime=lambda_.Runtime.PYTHON_3_11,
             handler="authorizer.handler",
             code=lambda_.Code.from_asset("src/lambda_authorizer"),
-            environment={"SYNAPSE_TEAM_ID": synapse_team_id},
+            environment=authorizer_env,
             timeout=cdk.Duration.seconds(10),
             memory_size=256,
         )
 
-        token_authorizer = apigw.TokenAuthorizer(
+        # REQUEST authorizer so the Lambda can read both Authorization and
+        # x-api-key headers.  Caching is disabled here; the Lambda does its
+        # own in-process token cache (5 min TTL) for warm instances.
+        token_authorizer = apigw.RequestAuthorizer(
             self,
-            "SynapseTokenAuthorizer",
+            "SynapseRequestAuthorizer",
             handler=authorizer_fn,
-            results_cache_ttl=cdk.Duration.minutes(5),
+            identity_sources=[apigw.IdentitySource.header("Authorization")],
+            results_cache_ttl=cdk.Duration.seconds(0),
         )
 
         # -------------------
@@ -214,7 +226,12 @@ class NeptuneApiStack(cdk.Stack):
             default_cors_preflight_options=apigw.CorsOptions(
                 allow_origins=apigw.Cors.ALL_ORIGINS,
                 allow_methods=["POST", "GET", "OPTIONS"],
-                allow_headers=["Content-Type", "Authorization", "X-Source"],
+                allow_headers=[
+                    "Content-Type",
+                    "Authorization",
+                    "X-Source",
+                    "x-api-key",
+                ],
             ),
             deploy_options=apigw.StageOptions(
                 access_log_destination=apigw.LogGroupLogDestination(access_log_group),

--- a/src/neptune_api_stack.py
+++ b/src/neptune_api_stack.py
@@ -39,6 +39,7 @@ class NeptuneApiStack(cdk.Stack):
         neptune_read_endpoint: str,
         neptune_cluster_resource_id: str,
         neptune_security_group: ec2.SecurityGroup,
+        synapse_team_id: str,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -175,6 +176,27 @@ class NeptuneApiStack(cdk.Stack):
         )
 
         # -------------------
+        # Synapse token authorizer Lambda (no VPC — calls Synapse public API)
+        # -------------------
+        authorizer_fn = lambda_.Function(
+            self,
+            "SynapseAuthorizerFunction",
+            runtime=lambda_.Runtime.PYTHON_3_11,
+            handler="authorizer.handler",
+            code=lambda_.Code.from_asset("src/lambda_authorizer"),
+            environment={"SYNAPSE_TEAM_ID": synapse_team_id},
+            timeout=cdk.Duration.seconds(10),
+            memory_size=256,
+        )
+
+        token_authorizer = apigw.TokenAuthorizer(
+            self,
+            "SynapseTokenAuthorizer",
+            handler=authorizer_fn,
+            results_cache_ttl=cdk.Duration.minutes(5),
+        )
+
+        # -------------------
         # API Gateway
         # -------------------
         access_log_group = logs.LogGroup(
@@ -192,6 +214,7 @@ class NeptuneApiStack(cdk.Stack):
             default_cors_preflight_options=apigw.CorsOptions(
                 allow_origins=apigw.Cors.ALL_ORIGINS,
                 allow_methods=["POST", "GET", "OPTIONS"],
+                allow_headers=["Content-Type", "Authorization", "X-Source"],
             ),
             deploy_options=apigw.StageOptions(
                 access_log_destination=apigw.LogGroupLogDestination(access_log_group),
@@ -217,12 +240,14 @@ class NeptuneApiStack(cdk.Stack):
         query_resource.add_method(
             "POST",
             apigw.LambdaIntegration(self.submit_fn, timeout=cdk.Duration.seconds(10)),
+            authorizer=token_authorizer,
         )
 
         query_job_resource = query_resource.add_resource("{job_id}")
         query_job_resource.add_method(
             "GET",
             apigw.LambdaIntegration(self.status_fn, timeout=cdk.Duration.seconds(10)),
+            authorizer=token_authorizer,
         )
 
         # -------------------

--- a/tests/unit/test_authorizer.py
+++ b/tests/unit/test_authorizer.py
@@ -54,21 +54,37 @@ def _event(token="Bearer real-token"):
     return {"headers": {"authorization": token}, "methodArn": METHOD_ARN}
 
 
-# Synapse /auth/v1/oauth2/userinfo response shapes
-MEMBER_USERINFO = {"sub": "999"}
-ANON_USERINFO = {}  # no sub/userid → treated as unauthenticated
+# /userProfile response shapes (PATs and OAuth tokens with 'view' scope)
+MEMBER_USERPROFILE = {"ownerId": "999", "userName": "testuser"}
+ANON_USERPROFILE = {}  # no ownerId → treated as unauthenticated
+
 IS_MEMBER = {"isMember": True}
 NOT_MEMBER = {"isMember": False}
 
+# OIDC userinfo response shape (OAuth tokens with 'openid' scope, no 'view')
+# sub is pairwise-opaque; userid is the numeric Synapse ID.
+MEMBER_USERINFO_OIDC = {
+    "userid": "999",
+    "sub": "opaque-pairwise-id",
+    "email": "test@example.com",
+}
+
+
+def _view_scope_forbidden():
+    """403 from /userProfile when the OAuth token lacks 'view' scope."""
+    return urllib.error.HTTPError(
+        url=None, code=403, msg="Forbidden", hdrs=None, fp=None
+    )
+
 
 # ---------------------------------------------------------------------------
-# Allow path
+# Allow path — PAT (view scope: /userProfile works directly)
 # ---------------------------------------------------------------------------
 
 
 @patch("authorizer.urllib.request.urlopen")
-def test_valid_member_returns_allow(mock_urlopen):
-    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERINFO, IS_MEMBER)
+def test_pat_member_returns_allow(mock_urlopen):
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERPROFILE, IS_MEMBER)
 
     result = auth_module.handler(_event(), {})
 
@@ -78,7 +94,7 @@ def test_valid_member_returns_allow(mock_urlopen):
 
 @patch("authorizer.urllib.request.urlopen")
 def test_allow_policy_wildcards_api_resource(mock_urlopen):
-    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERINFO, IS_MEMBER)
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERPROFILE, IS_MEMBER)
 
     result = auth_module.handler(_event(), {})
 
@@ -87,11 +103,41 @@ def test_allow_policy_wildcards_api_resource(mock_urlopen):
 
 @patch("authorizer.urllib.request.urlopen")
 def test_allow_context_contains_user_id(mock_urlopen):
-    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERINFO, IS_MEMBER)
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERPROFILE, IS_MEMBER)
 
     result = auth_module.handler(_event(), {})
 
     assert result["context"]["user_id"] == "999"
+
+
+# ---------------------------------------------------------------------------
+# Allow path — OAuth token (openid only: /userProfile 403 → OIDC fallback)
+# ---------------------------------------------------------------------------
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_oauth_openid_only_falls_back_to_oidc_and_allows(mock_urlopen):
+    """OAuth token without 'view' scope: /userProfile 403 → OIDC userid → allow."""
+    mock_urlopen.side_effect = _urlopen_mock(
+        _view_scope_forbidden(), MEMBER_USERINFO_OIDC, IS_MEMBER
+    )
+
+    result = auth_module.handler(_event(), {})
+
+    assert result["policyDocument"]["Statement"][0]["Effect"] == "Allow"
+    assert result["principalId"] == "999"
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_oauth_openid_only_non_member_denied(mock_urlopen):
+    """OAuth token falls back to OIDC but user is not in team → deny."""
+    mock_urlopen.side_effect = _urlopen_mock(
+        _view_scope_forbidden(), MEMBER_USERINFO_OIDC, NOT_MEMBER
+    )
+
+    result = auth_module.handler(_event(), {})
+
+    assert result["policyDocument"]["Statement"][0]["Effect"] == "Deny"
 
 
 # ---------------------------------------------------------------------------
@@ -100,8 +146,8 @@ def test_allow_context_contains_user_id(mock_urlopen):
 
 
 @patch("authorizer.urllib.request.urlopen")
-def test_anonymous_profile_returns_deny(mock_urlopen):
-    mock_urlopen.side_effect = _urlopen_mock(ANON_USERINFO)
+def test_no_owner_id_returns_deny(mock_urlopen):
+    mock_urlopen.side_effect = _urlopen_mock(ANON_USERPROFILE)
 
     result = auth_module.handler(_event(), {})
 
@@ -110,7 +156,7 @@ def test_anonymous_profile_returns_deny(mock_urlopen):
 
 @patch("authorizer.urllib.request.urlopen")
 def test_non_member_returns_deny(mock_urlopen):
-    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERINFO, NOT_MEMBER)
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERPROFILE, NOT_MEMBER)
 
     result = auth_module.handler(_event(), {})
 
@@ -143,11 +189,13 @@ def test_synapse_401_on_profile_returns_deny(mock_urlopen):
 
 
 @patch("authorizer.urllib.request.urlopen")
-def test_synapse_401_on_membership_returns_deny(mock_urlopen):
+def test_membership_400_returns_deny(mock_urlopen):
+    # Synapse returns 400 when the userId is not found or malformed.
+    # Treat as a clean deny rather than crashing into a 500.
     mock_urlopen.side_effect = _urlopen_mock(
-        MEMBER_USERINFO,
+        MEMBER_USERPROFILE,
         urllib.error.HTTPError(
-            url=None, code=401, msg="Unauthorized", hdrs=None, fp=None
+            url=None, code=400, msg="Bad Request", hdrs=None, fp=None
         ),
     )
 
@@ -159,6 +207,21 @@ def test_synapse_401_on_membership_returns_deny(mock_urlopen):
 # ---------------------------------------------------------------------------
 # Transient errors — must propagate (not cached as Deny)
 # ---------------------------------------------------------------------------
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_synapse_error_on_membership_propagates(mock_urlopen):
+    # 5xx errors on the membership endpoint are unexpected transient failures and
+    # should propagate so valid users aren't locked out during a Synapse outage.
+    mock_urlopen.side_effect = _urlopen_mock(
+        MEMBER_USERPROFILE,
+        urllib.error.HTTPError(
+            url=None, code=500, msg="Internal Server Error", hdrs=None, fp=None
+        ),
+    )
+
+    with pytest.raises(urllib.error.HTTPError):
+        auth_module.handler(_event(), {})
 
 
 @patch("authorizer.urllib.request.urlopen")
@@ -192,7 +255,7 @@ def test_network_error_propagates(mock_urlopen):
 def test_token_not_logged_on_deny(mock_urlopen, caplog):
     import logging
 
-    mock_urlopen.side_effect = _urlopen_mock(ANON_USERINFO)
+    mock_urlopen.side_effect = _urlopen_mock(ANON_USERPROFILE)
     secret_token = "super-secret-pat-value"
 
     with caplog.at_level(logging.WARNING, logger="root"):
@@ -206,7 +269,7 @@ def test_token_not_logged_on_deny(mock_urlopen, caplog):
 def test_token_not_logged_on_allow(mock_urlopen, caplog):
     import logging
 
-    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERINFO, IS_MEMBER)
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERPROFILE, IS_MEMBER)
     secret_token = "super-secret-pat-value"
 
     with caplog.at_level(logging.INFO, logger="root"):

--- a/tests/unit/test_authorizer.py
+++ b/tests/unit/test_authorizer.py
@@ -16,6 +16,12 @@ if LAMBDA_DIR not in sys.path:
 
 import authorizer as auth_module  # noqa: E402
 
+
+@pytest.fixture(autouse=True)
+def clear_token_cache():
+    auth_module._token_cache.clear()
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -44,11 +50,13 @@ def _urlopen_mock(*responses):
 
 
 def _event(token="Bearer real-token"):
-    return {"authorizationToken": token, "methodArn": METHOD_ARN}
+    # REQUEST authorizer: credentials arrive in event["headers"]
+    return {"headers": {"authorization": token}, "methodArn": METHOD_ARN}
 
 
-MEMBER_PROFILE = {"ownerId": "999", "userName": "testuser"}
-ANON_PROFILE = {"ownerId": "273950", "userName": "anonymous"}
+# Synapse /auth/v1/oauth2/userinfo response shapes
+MEMBER_USERINFO = {"sub": "999"}
+ANON_USERINFO = {}  # no sub/userid → treated as unauthenticated
 IS_MEMBER = {"isMember": True}
 NOT_MEMBER = {"isMember": False}
 
@@ -60,7 +68,7 @@ NOT_MEMBER = {"isMember": False}
 
 @patch("authorizer.urllib.request.urlopen")
 def test_valid_member_returns_allow(mock_urlopen):
-    mock_urlopen.side_effect = _urlopen_mock(MEMBER_PROFILE, IS_MEMBER)
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERINFO, IS_MEMBER)
 
     result = auth_module.handler(_event(), {})
 
@@ -70,7 +78,7 @@ def test_valid_member_returns_allow(mock_urlopen):
 
 @patch("authorizer.urllib.request.urlopen")
 def test_allow_policy_wildcards_api_resource(mock_urlopen):
-    mock_urlopen.side_effect = _urlopen_mock(MEMBER_PROFILE, IS_MEMBER)
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERINFO, IS_MEMBER)
 
     result = auth_module.handler(_event(), {})
 
@@ -79,7 +87,7 @@ def test_allow_policy_wildcards_api_resource(mock_urlopen):
 
 @patch("authorizer.urllib.request.urlopen")
 def test_allow_context_contains_user_id(mock_urlopen):
-    mock_urlopen.side_effect = _urlopen_mock(MEMBER_PROFILE, IS_MEMBER)
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERINFO, IS_MEMBER)
 
     result = auth_module.handler(_event(), {})
 
@@ -93,7 +101,7 @@ def test_allow_context_contains_user_id(mock_urlopen):
 
 @patch("authorizer.urllib.request.urlopen")
 def test_anonymous_profile_returns_deny(mock_urlopen):
-    mock_urlopen.side_effect = _urlopen_mock(ANON_PROFILE)
+    mock_urlopen.side_effect = _urlopen_mock(ANON_USERINFO)
 
     result = auth_module.handler(_event(), {})
 
@@ -102,7 +110,7 @@ def test_anonymous_profile_returns_deny(mock_urlopen):
 
 @patch("authorizer.urllib.request.urlopen")
 def test_non_member_returns_deny(mock_urlopen):
-    mock_urlopen.side_effect = _urlopen_mock(MEMBER_PROFILE, NOT_MEMBER)
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERINFO, NOT_MEMBER)
 
     result = auth_module.handler(_event(), {})
 
@@ -137,7 +145,7 @@ def test_synapse_401_on_profile_returns_deny(mock_urlopen):
 @patch("authorizer.urllib.request.urlopen")
 def test_synapse_401_on_membership_returns_deny(mock_urlopen):
     mock_urlopen.side_effect = _urlopen_mock(
-        MEMBER_PROFILE,
+        MEMBER_USERINFO,
         urllib.error.HTTPError(
             url=None, code=401, msg="Unauthorized", hdrs=None, fp=None
         ),
@@ -184,7 +192,7 @@ def test_network_error_propagates(mock_urlopen):
 def test_token_not_logged_on_deny(mock_urlopen, caplog):
     import logging
 
-    mock_urlopen.side_effect = _urlopen_mock(ANON_PROFILE)
+    mock_urlopen.side_effect = _urlopen_mock(ANON_USERINFO)
     secret_token = "super-secret-pat-value"
 
     with caplog.at_level(logging.WARNING, logger="root"):
@@ -198,7 +206,7 @@ def test_token_not_logged_on_deny(mock_urlopen, caplog):
 def test_token_not_logged_on_allow(mock_urlopen, caplog):
     import logging
 
-    mock_urlopen.side_effect = _urlopen_mock(MEMBER_PROFILE, IS_MEMBER)
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_USERINFO, IS_MEMBER)
     secret_token = "super-secret-pat-value"
 
     with caplog.at_level(logging.INFO, logger="root"):

--- a/tests/unit/test_authorizer.py
+++ b/tests/unit/test_authorizer.py
@@ -1,0 +1,208 @@
+import json
+import os
+import sys
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# SYNAPSE_TEAM_ID is read at import time, so set it before the first import.
+os.environ.setdefault("SYNAPSE_TEAM_ID", "273957")
+
+LAMBDA_DIR = str(Path(__file__).parents[2] / "src" / "lambda_authorizer")
+if LAMBDA_DIR not in sys.path:
+    sys.path.insert(0, LAMBDA_DIR)
+
+import authorizer as auth_module  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+METHOD_ARN = "arn:aws:execute-api:us-east-1:123456789012:abc123/prod/POST/ask"
+EXPECTED_RESOURCE = "arn:aws:execute-api:us-east-1:123456789012:abc123/*/*"
+
+
+def _urlopen_mock(*responses):
+    """
+    Return a side_effect list for urlopen, where each item is either:
+      - a dict  → successful 200 response with that JSON body
+      - an exception instance → raised directly
+    """
+    side_effects = []
+    for resp in responses:
+        if isinstance(resp, Exception):
+            side_effects.append(resp)
+        else:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(resp).encode()
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            side_effects.append(mock_resp)
+    return side_effects
+
+
+def _event(token="Bearer real-token"):
+    return {"authorizationToken": token, "methodArn": METHOD_ARN}
+
+
+MEMBER_PROFILE = {"ownerId": "999", "userName": "testuser"}
+ANON_PROFILE = {"ownerId": "273950", "userName": "anonymous"}
+IS_MEMBER = {"isMember": True}
+NOT_MEMBER = {"isMember": False}
+
+
+# ---------------------------------------------------------------------------
+# Allow path
+# ---------------------------------------------------------------------------
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_valid_member_returns_allow(mock_urlopen):
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_PROFILE, IS_MEMBER)
+
+    result = auth_module.handler(_event(), {})
+
+    assert result["policyDocument"]["Statement"][0]["Effect"] == "Allow"
+    assert result["principalId"] == "999"
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_allow_policy_wildcards_api_resource(mock_urlopen):
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_PROFILE, IS_MEMBER)
+
+    result = auth_module.handler(_event(), {})
+
+    assert result["policyDocument"]["Statement"][0]["Resource"] == EXPECTED_RESOURCE
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_allow_context_contains_user_id(mock_urlopen):
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_PROFILE, IS_MEMBER)
+
+    result = auth_module.handler(_event(), {})
+
+    assert result["context"]["user_id"] == "999"
+
+
+# ---------------------------------------------------------------------------
+# Deny path — expected auth failures
+# ---------------------------------------------------------------------------
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_anonymous_profile_returns_deny(mock_urlopen):
+    mock_urlopen.side_effect = _urlopen_mock(ANON_PROFILE)
+
+    result = auth_module.handler(_event(), {})
+
+    assert result["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_non_member_returns_deny(mock_urlopen):
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_PROFILE, NOT_MEMBER)
+
+    result = auth_module.handler(_event(), {})
+
+    assert result["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+
+
+def test_missing_bearer_prefix_returns_deny():
+    result = auth_module.handler(_event(token="notabearer"), {})
+
+    assert result["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+
+
+def test_empty_token_returns_deny():
+    result = auth_module.handler(_event(token=""), {})
+
+    assert result["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_synapse_401_on_profile_returns_deny(mock_urlopen):
+    mock_urlopen.side_effect = _urlopen_mock(
+        urllib.error.HTTPError(
+            url=None, code=401, msg="Unauthorized", hdrs=None, fp=None
+        )
+    )
+
+    result = auth_module.handler(_event(), {})
+
+    assert result["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_synapse_401_on_membership_returns_deny(mock_urlopen):
+    mock_urlopen.side_effect = _urlopen_mock(
+        MEMBER_PROFILE,
+        urllib.error.HTTPError(
+            url=None, code=401, msg="Unauthorized", hdrs=None, fp=None
+        ),
+    )
+
+    result = auth_module.handler(_event(), {})
+
+    assert result["policyDocument"]["Statement"][0]["Effect"] == "Deny"
+
+
+# ---------------------------------------------------------------------------
+# Transient errors — must propagate (not cached as Deny)
+# ---------------------------------------------------------------------------
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_synapse_5xx_propagates(mock_urlopen):
+    mock_urlopen.side_effect = _urlopen_mock(
+        urllib.error.HTTPError(
+            url=None, code=500, msg="Internal Server Error", hdrs=None, fp=None
+        )
+    )
+
+    with pytest.raises(urllib.error.HTTPError):
+        auth_module.handler(_event(), {})
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_network_error_propagates(mock_urlopen):
+    mock_urlopen.side_effect = _urlopen_mock(
+        urllib.error.URLError("connection timed out")
+    )
+
+    with pytest.raises(urllib.error.URLError):
+        auth_module.handler(_event(), {})
+
+
+# ---------------------------------------------------------------------------
+# Token safety — token must never appear in log output
+# ---------------------------------------------------------------------------
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_token_not_logged_on_deny(mock_urlopen, caplog):
+    import logging
+
+    mock_urlopen.side_effect = _urlopen_mock(ANON_PROFILE)
+    secret_token = "super-secret-pat-value"
+
+    with caplog.at_level(logging.WARNING, logger="root"):
+        auth_module.handler(_event(token=f"Bearer {secret_token}"), {})
+
+    for record in caplog.records:
+        assert secret_token not in record.getMessage()
+
+
+@patch("authorizer.urllib.request.urlopen")
+def test_token_not_logged_on_allow(mock_urlopen, caplog):
+    import logging
+
+    mock_urlopen.side_effect = _urlopen_mock(MEMBER_PROFILE, IS_MEMBER)
+    secret_token = "super-secret-pat-value"
+
+    with caplog.at_level(logging.INFO, logger="root"):
+        auth_module.handler(_event(token=f"Bearer {secret_token}"), {})
+
+    for record in caplog.records:
+        assert secret_token not in record.getMessage()

--- a/tests/unit/test_monitoring_stack.py
+++ b/tests/unit/test_monitoring_stack.py
@@ -10,7 +10,7 @@ from aws_cdk.assertions import Template
 from src.monitoring_stack import MonitoringStack
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def template():
     app = cdk.App()
 

--- a/tests/unit/test_monitoring_stack.py
+++ b/tests/unit/test_monitoring_stack.py
@@ -12,7 +12,7 @@ from src.monitoring_stack import MonitoringStack
 
 @pytest.fixture(scope="module")
 def template():
-    app = cdk.App()
+    app = cdk.App(context={"@aws-cdk/core:bundlingStacks": []})
 
     # VPC (shared across helper stacks)
     vpc_stack = cdk.Stack(app, "TestVpc")

--- a/tests/unit/test_neptune_agent_stack.py
+++ b/tests/unit/test_neptune_agent_stack.py
@@ -8,7 +8,7 @@ from src.neptune_agent_stack import NeptuneAgentStack
 
 @pytest.fixture(scope="module")
 def template():
-    app = cdk.App()
+    app = cdk.App(context={"@aws-cdk/core:bundlingStacks": []})
 
     vpc_stack = cdk.Stack(app, "TestVpcStack")
     vpc = ec2.Vpc(vpc_stack, "TestVpc", max_azs=2)

--- a/tests/unit/test_neptune_agent_stack.py
+++ b/tests/unit/test_neptune_agent_stack.py
@@ -1,0 +1,126 @@
+import aws_cdk as cdk
+import pytest
+from aws_cdk import aws_ec2 as ec2
+from aws_cdk.assertions import Match, Template
+
+from src.neptune_agent_stack import NeptuneAgentStack
+
+
+@pytest.fixture
+def template():
+    app = cdk.App()
+
+    vpc_stack = cdk.Stack(app, "TestVpcStack")
+    vpc = ec2.Vpc(vpc_stack, "TestVpc", max_azs=2)
+
+    stack = NeptuneAgentStack(
+        app,
+        "TestNeptuneAgentStack",
+        vpc=vpc,
+        neptune_query_url="https://example.execute-api.us-east-1.amazonaws.com/prod/query",
+        neptune_query_status_url="https://example.execute-api.us-east-1.amazonaws.com/prod/query",
+        synapse_team_id="273957",
+    )
+    return Template.from_stack(stack)
+
+
+# ---------------------------------------------------------------------------
+# Lambda
+# ---------------------------------------------------------------------------
+
+
+def test_submit_and_status_lambda_created(template):
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {"Handler": "submit.handler", "Timeout": 10},
+    )
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {"Handler": "status.handler", "Timeout": 10},
+    )
+
+
+def test_agent_worker_lambda_created(template):
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {"Handler": "agent.handler", "Timeout": 300},
+    )
+
+
+def test_authorizer_lambda_has_team_id_env(template):
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "Handler": "authorizer.handler",
+            "Environment": {"Variables": {"SYNAPSE_TEAM_ID": "273957"}},
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# API Gateway — authentication
+# ---------------------------------------------------------------------------
+
+
+def test_api_gateway_created(template):
+    template.has_resource_properties(
+        "AWS::ApiGateway::RestApi",
+        {"Name": "neptune-agent-api"},
+    )
+
+
+def test_post_method_has_custom_authorizer(template):
+    template.has_resource_properties(
+        "AWS::ApiGateway::Method",
+        {
+            "HttpMethod": "POST",
+            "AuthorizationType": "CUSTOM",
+            "AuthorizerId": Match.any_value(),
+        },
+    )
+
+
+def test_get_method_has_custom_authorizer(template):
+    template.has_resource_properties(
+        "AWS::ApiGateway::Method",
+        {
+            "HttpMethod": "GET",
+            "AuthorizationType": "CUSTOM",
+            "AuthorizerId": Match.any_value(),
+        },
+    )
+
+
+def test_options_method_has_no_authorizer(template):
+    # CORS preflight must not be gated — browsers can't send auth on OPTIONS
+    template.has_resource_properties(
+        "AWS::ApiGateway::Method",
+        {"HttpMethod": "OPTIONS", "AuthorizationType": "NONE"},
+    )
+
+
+def test_token_authorizer_created(template):
+    template.has_resource_properties(
+        "AWS::ApiGateway::Authorizer",
+        {
+            "Type": "TOKEN",
+            "AuthorizerResultTtlInSeconds": 300,
+            "IdentitySource": "method.request.header.Authorization",
+        },
+    )
+
+
+def test_gateway_response_remaps_access_denied_to_401(template):
+    template.has_resource_properties(
+        "AWS::ApiGateway::GatewayResponse",
+        {"ResponseType": "ACCESS_DENIED", "StatusCode": "401"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+
+
+def test_agent_api_url_output_exists(template):
+    template.has_output("AgentApiUrl", {})

--- a/tests/unit/test_neptune_agent_stack.py
+++ b/tests/unit/test_neptune_agent_stack.py
@@ -6,7 +6,7 @@ from aws_cdk.assertions import Match, Template
 from src.neptune_agent_stack import NeptuneAgentStack
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def template():
     app = cdk.App()
 

--- a/tests/unit/test_neptune_agent_stack.py
+++ b/tests/unit/test_neptune_agent_stack.py
@@ -117,6 +117,18 @@ def test_gateway_response_remaps_access_denied_to_401(template):
     )
 
 
+def test_gateway_response_unauthorized_has_cors_header(template):
+    template.has_resource_properties(
+        "AWS::ApiGateway::GatewayResponse",
+        {
+            "ResponseType": "UNAUTHORIZED",
+            "ResponseParameters": {
+                "gatewayresponse.header.Access-Control-Allow-Origin": "'*'"
+            },
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # Outputs
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_neptune_agent_stack.py
+++ b/tests/unit/test_neptune_agent_stack.py
@@ -99,12 +99,12 @@ def test_options_method_has_no_authorizer(template):
     )
 
 
-def test_token_authorizer_created(template):
+def test_request_authorizer_created(template):
     template.has_resource_properties(
         "AWS::ApiGateway::Authorizer",
         {
-            "Type": "TOKEN",
-            "AuthorizerResultTtlInSeconds": 300,
+            "Type": "REQUEST",
+            "AuthorizerResultTtlInSeconds": 0,
             "IdentitySource": "method.request.header.Authorization",
         },
     )

--- a/tests/unit/test_neptune_api_stack.py
+++ b/tests/unit/test_neptune_api_stack.py
@@ -173,6 +173,64 @@ def test_options_method_exists_for_cors(template):
     )
 
 
+def test_post_method_has_custom_authorizer(template):
+    template.has_resource_properties(
+        "AWS::ApiGateway::Method",
+        {
+            "HttpMethod": "POST",
+            "AuthorizationType": "CUSTOM",
+            "AuthorizerId": Match.any_value(),
+        },
+    )
+
+
+def test_get_method_has_custom_authorizer(template):
+    template.has_resource_properties(
+        "AWS::ApiGateway::Method",
+        {
+            "HttpMethod": "GET",
+            "AuthorizationType": "CUSTOM",
+            "AuthorizerId": Match.any_value(),
+        },
+    )
+
+
+def test_options_method_has_no_authorizer(template):
+    # CORS preflight must not be gated — browsers can't send auth on OPTIONS
+    template.has_resource_properties(
+        "AWS::ApiGateway::Method",
+        {"HttpMethod": "OPTIONS", "AuthorizationType": "NONE"},
+    )
+
+
+def test_token_authorizer_created(template):
+    template.has_resource_properties(
+        "AWS::ApiGateway::Authorizer",
+        {
+            "Type": "TOKEN",
+            "AuthorizerResultTtlInSeconds": 300,
+            "IdentitySource": "method.request.header.Authorization",
+        },
+    )
+
+
+def test_authorizer_lambda_has_team_id_env(template):
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "Handler": "authorizer.handler",
+            "Environment": {"Variables": {"SYNAPSE_TEAM_ID": "273957"}},
+        },
+    )
+
+
+def test_gateway_response_remaps_access_denied_to_401(template):
+    template.has_resource_properties(
+        "AWS::ApiGateway::GatewayResponse",
+        {"ResponseType": "ACCESS_DENIED", "StatusCode": "401"},
+    )
+
+
 def test_stage_has_throttling(template):
     template.has_resource_properties(
         "AWS::ApiGateway::Stage",

--- a/tests/unit/test_neptune_api_stack.py
+++ b/tests/unit/test_neptune_api_stack.py
@@ -203,12 +203,12 @@ def test_options_method_has_no_authorizer(template):
     )
 
 
-def test_token_authorizer_created(template):
+def test_request_authorizer_created(template):
     template.has_resource_properties(
         "AWS::ApiGateway::Authorizer",
         {
-            "Type": "TOKEN",
-            "AuthorizerResultTtlInSeconds": 300,
+            "Type": "REQUEST",
+            "AuthorizerResultTtlInSeconds": 0,
             "IdentitySource": "method.request.header.Authorization",
         },
     )

--- a/tests/unit/test_neptune_api_stack.py
+++ b/tests/unit/test_neptune_api_stack.py
@@ -25,6 +25,7 @@ def template():
         neptune_read_endpoint="test-neptune.cluster-ro.us-east-1.neptune.amazonaws.com",
         neptune_cluster_resource_id="cluster-ABCDEFGHIJKLMNOP",
         neptune_security_group=neptune_sg,
+        synapse_team_id="273957",
     )
     return Template.from_stack(stack)
 

--- a/tests/unit/test_neptune_api_stack.py
+++ b/tests/unit/test_neptune_api_stack.py
@@ -231,6 +231,18 @@ def test_gateway_response_remaps_access_denied_to_401(template):
     )
 
 
+def test_gateway_response_unauthorized_has_cors_header(template):
+    template.has_resource_properties(
+        "AWS::ApiGateway::GatewayResponse",
+        {
+            "ResponseType": "UNAUTHORIZED",
+            "ResponseParameters": {
+                "gatewayresponse.header.Access-Control-Allow-Origin": "'*'"
+            },
+        },
+    )
+
+
 def test_stage_has_throttling(template):
     template.has_resource_properties(
         "AWS::ApiGateway::Stage",

--- a/tests/unit/test_neptune_api_stack.py
+++ b/tests/unit/test_neptune_api_stack.py
@@ -6,7 +6,7 @@ from aws_cdk.assertions import Match, Template
 from src.neptune_api_stack import NeptuneApiStack
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def template():
     app = cdk.App()
 

--- a/tests/unit/test_neptune_api_stack.py
+++ b/tests/unit/test_neptune_api_stack.py
@@ -8,7 +8,7 @@ from src.neptune_api_stack import NeptuneApiStack
 
 @pytest.fixture(scope="module")
 def template():
-    app = cdk.App()
+    app = cdk.App(context={"@aws-cdk/core:bundlingStacks": []})
 
     vpc_stack = cdk.Stack(app, "TestVpcStack")
     vpc = ec2.Vpc(vpc_stack, "TestVpc", max_azs=2)

--- a/tests/unit/test_neptune_sagemaker_stack.py
+++ b/tests/unit/test_neptune_sagemaker_stack.py
@@ -9,7 +9,7 @@ from src.neptune_sagemaker_stack import NeptuneSageMakerStack
 CLUSTER_RESOURCE_ID = "cluster-ABCDEFGHIJKLMNOP"
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def template():
     app = cdk.App()
 


### PR DESCRIPTION
## What

Fixes #29
Adds a [Synapse](https://www.synapse.org)-federated API Gateway Lambda Authorizer to both the `/query` and `/ask` endpoints. Callers must present a Synapse Personal Access Token (PAT) or OAuth access token and be a member of Synapse team [273957](https://www.synapse.org/Team:273957).

## How it works

```
Authorization: Bearer <synapse_token>
       ↓
API Gateway calls SynapseAuthorizerFunction (before routing)
       ↓
GET repo-prod.prod.sagebase.org/repo/v1/userProfile                      ← validates token, gets ownerId
GET .../team/273957/member/{ownerId}/membershipStatus                     ← 200 + isMember=true = Allow
                                                                             200 + isMember=false = Deny
                                                                             401/403 = Deny
       ↓
Allow → forwards to submit / status Lambda
Deny  → 401, never touches downstream Lambdas
```

- Authorizer result is cached 5 min per token by API Gateway (avoids hammering Synapse)
- OPTIONS preflight requests are not gated — CORS still works for browsers
- No external deps — uses Python stdlib (`urllib`, `json`)
- Both APIs share the same authorizer code from `src/lambda_authorizer/`

## OAuth UI path

When a UI uses Synapse OAuth, the OAuth flow returns a Synapse access token in the same Bearer token format — the authorizer needs zero changes.

## Changes

- `src/lambda_authorizer/authorizer.py` — new Lambda (~50 lines)
- `config/base.yaml` — added `AUTH.synapse_team_id: "273957"`
- `src/neptune_api_stack.py` — authorizer + CORS `Authorization` header for `POST /query`, `GET /query/{job_id}`
- `src/neptune_agent_stack.py` — same for `POST /ask`, `GET /ask/{job_id}`
- `app.py` — passes `synapse_team_id` to both stacks
- `tests/unit/test_neptune_api_stack.py` — fixture updated

## PR Checklist

- [x] Clearly explain your change with a descriptive commit message
- [x] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`