### PR TITLE
Set bulk loader mode to NEW instead of inheriting AUTO

### DIFF
--- a/src/lambda_loader/loader.py
+++ b/src/lambda_loader/loader.py
@@ -118,7 +118,15 @@ def _start_bulk_load(prefix: str, named_graph: str) -> str:
         "format": "turtle",
         "iamRoleArn": NEPTUNE_LOAD_ROLE_ARN,
         "region": REGION,
+        # NEW, never the AUTO default: AUTO resumes a prior job from the same
+        # source, and our source is byte-identical on a re-publish of the same
+        # date. RESUME semantics would then reload nothing and return success,
+        # so corrected data would never land while the tracking table recorded
+        # a completed load. NEW also means dropped graph data does get reloaded.
+        "mode": "NEW",
         # Append-only: surface bad data instead of silently skipping it.
+        # Caveat: on error the loader stops but data loaded up to that point
+        # persists, so a failed load leaves a partial named graph behind.
         "failOnError": "TRUE",
         "parallelism": PARALLELISM,
         # Queue behind any in-flight load rather than erroring on a busy cluster.

--- a/tests/unit/test_loader_handler.py
+++ b/tests/unit/test_loader_handler.py
@@ -101,6 +101,9 @@ def test_start_submits_load_into_named_graph(loader, mock_table):
     assert body["source"] == "s3://mybucket/nf/2026-04-25/data/"
     assert body["format"] == "turtle"
     assert body["failOnError"] == "TRUE"
+    # Never AUTO: AUTO would resume the prior job for this source and no-op a
+    # re-publish of the same date, reporting success without loading anything.
+    assert body["mode"] == "NEW"
     assert body["parserConfiguration"]["namedGraphUri"] == "urn:sagebrain:nf:2026-04-25"
 
     # in_progress row written


### PR DESCRIPTION
Sets `"mode": "NEW"` explicitly on the Neptune bulk-load payload in `src/lambda_loader/loader.py`, which previously omitted `mode` and inherited Neptune's `AUTO` default.

## Why

AUTO resumes a prior load job from the same source using RESUME semantics. Our source is `s3://{bucket}/{portal}/{date}/data/` — byte-identical on a re-publish of the same date — and per the loader docs, RESUME reloads nothing and returns success if the previous job loaded all files from that source.

The failure mode was silent:

- new manifest etag → passes the etag idempotency check → load submitted
- Neptune no-ops → `LOAD_COMPLETED`
- `RecordSuccess` writes `status=complete`, graph unchanged

No error anywhere, and the tracking table claimed the load worked. RESUME also skips per-file by name, so retry-after-fix was broken too: a corrected file that had already loaded successfully in a failed job would be skipped.

It was nondeterministic over time — Neptune keeps only the most recent 1,024 load jobs, so once the earlier job aged out, AUTO fell through to NEW behavior and the same re-publish would suddenly work.

NEW's own doc text names this use case, and it's a prerequisite for any future `DROP GRAPH` cleanup, since RESUME won't reload data dropped from the cluster.

## Scope

Payload change and one test assertion only. The partial-graph-on-failure cleanup (`DROP GRAPH`, staging-graph swap, read-side filtering on the tracking table) is deliberately not included here.

## Testing

`python -m pytest tests/unit/test_loader_handler.py` — 10 passed.

Behavior is verified against the loader docs, not observed. A re-publish into an existing date in dev would confirm it empirically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
